### PR TITLE
[UI] Added navigation bar to template

### DIFF
--- a/lib/views/widgets/template.dart
+++ b/lib/views/widgets/template.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:sun_flutter_capstone/consts/global_style.dart';
+import 'package:sun_flutter_capstone/views/widgets/navigation/floating_action_button.dart';
+import 'package:sun_flutter_capstone/views/widgets/navigation/navigation.dart';
 
 class Template extends StatelessWidget {
   final Widget content;
@@ -65,6 +67,9 @@ class Template extends StatelessWidget {
           ),
         ],
       ),
+      floatingActionButton: const CenterActionButton(),
+      floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
+      bottomNavigationBar: const Navigation(),
     );
   }
 }


### PR DESCRIPTION
## Related Links:
- [Issue link](https://www.notion.so/Bugfix-Display-header-and-bottom-navigation-in-same-sample-page-9a27539c222642e0bba9b02a2e41695a)

## Definition of Done
- [x] Add navigation bar to template

## Notes:
- N/A

## Screenshots
![image](https://user-images.githubusercontent.com/86587091/164189616-c69c3aee-5736-41e1-9a90-8508d6bab626.png)

## Test View  Points
- [ ] can see header layout with sample content and navigation bar
