### PR TITLE
[UI] Added reusable date field

### DIFF
--- a/lib/consts/global_style.dart
+++ b/lib/consts/global_style.dart
@@ -35,3 +35,20 @@ const appBarTheme = AppBarTheme(
 const textTheme = TextTheme(
   bodyText2: TextStyle(fontSize: 14, color: AppColor.gray),
 );
+
+// TODO: FOR ROUNDED INPUT FIELD
+const rounded = BorderRadius.all(
+  Radius.circular(8),
+);
+
+// TODO: THEME FOR ALL INPUT FIELDS
+const inputDecorationTheme = InputDecorationTheme(
+  focusedBorder: OutlineInputBorder(
+    borderSide: BorderSide(color: AppColor.secondary),
+    borderRadius: rounded,
+  ),
+  enabledBorder: OutlineInputBorder(
+    borderSide: BorderSide(color: AppColor.lightGray),
+    borderRadius: rounded,
+  ),
+);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 // import 'package:auto_route/auto_route.dart'; Uncomment to use in the future
 import 'package:sun_flutter_capstone/utils/routes/router.gr.dart';
+import 'package:sun_flutter_capstone/consts/global_style.dart';
 
 import 'package:sun_flutter_capstone/consts/global_style.dart';
 
@@ -27,6 +28,7 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         appBarTheme: appBarTheme,
         fontFamily: 'Inter',
+        inputDecorationTheme: inputDecorationTheme,
       ),
       routerDelegate: _appRouter.delegate(),
       routeInformationParser: _appRouter.defaultRouteParser(),

--- a/lib/views/pages/sample_with_appbar.dart
+++ b/lib/views/pages/sample_with_appbar.dart
@@ -3,6 +3,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:sun_flutter_capstone/state/session_provider.dart';
 import 'package:sun_flutter_capstone/utils/routing.dart';
 import 'package:sun_flutter_capstone/views/widgets/template.dart';
+import 'package:sun_flutter_capstone/views/widgets/date_field.dart';
 
 class SamplePageWithAppBar extends HookConsumerWidget {
   const SamplePageWithAppBar({Key? key}) : super(key: key);
@@ -10,20 +11,25 @@ class SamplePageWithAppBar extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return Template(
-        appbarTitle: const Text('Sample title here'),
-        content: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            const Center(child: Text('sample content here')),
-            ElevatedButton(
-              onPressed: () => goToHome(context),
-              child: const Text('Home'),
-            ),
-            ElevatedButton(
-              onPressed: () => setSessionUsername(ref, 'Hello'),
-              child: const Text('Login As Hello'),
-            )
-          ],
-        ));
+      appbarTitle: Text('Sample title here'),
+      content: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const Center(child: Text('sample content here')),
+          ElevatedButton(
+            onPressed: () => goToHome(context),
+            child: const Text('Home'),
+          ),
+          ElevatedButton(
+            onPressed: () => setSessionUsername(ref, 'Hello'),
+            child: const Text('Login As Hello'),
+          ),
+          DateField(
+            firstDate: DateTime(DateTime.now().year, 1),
+            lastDate: DateTime.now(),
+          ),
+        ],
+      ),
+    );
   }
 }

--- a/lib/views/pages/welcome.dart
+++ b/lib/views/pages/welcome.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:sun_flutter_capstone/utils/routing.dart';
+
+class WelcomePage extends StatelessWidget {
+  const WelcomePage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        children: [
+          ElevatedButton(
+              onPressed: () => {navigateTo(context, '/login')},
+              child: const Text('Login')),
+          ElevatedButton(
+              onPressed: () => {navigateTo(context, '/register')},
+              child: const Text('Register'))
+        ],
+      ),
+    );
+  }
+}

--- a/lib/views/pages/welcome.dart
+++ b/lib/views/pages/welcome.dart
@@ -10,11 +10,17 @@ class WelcomePage extends StatelessWidget {
       child: Column(
         children: [
           ElevatedButton(
-              onPressed: () => {navigateTo(context, '/login')},
-              child: const Text('Login')),
+            onPressed: () => {
+              navigateTo(context, '/login'),
+            },
+            child: const Text('Login'),
+          ),
           ElevatedButton(
-              onPressed: () => {navigateTo(context, '/register')},
-              child: const Text('Register'))
+            onPressed: () => {
+              navigateTo(context, '/register'),
+            },
+            child: const Text('Register'),
+          ),
         ],
       ),
     );

--- a/lib/views/widgets/date_field.dart
+++ b/lib/views/widgets/date_field.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:sun_flutter_capstone/consts/global_style.dart';
+
+class DateField extends StatefulWidget {
+  final DateTime firstDate;
+  final DateTime lastDate;
+  DateField({
+    Key? key,
+    required this.firstDate,
+    required this.lastDate,
+  }) : super(key: key);
+
+  @override
+  State<DateField> createState() => _DateFieldState();
+}
+
+class _DateFieldState extends State<DateField> {  
+  DateTime selectedDate = DateTime.now();
+
+  @override
+  Widget build(BuildContext context) {    
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Padding(
+          padding: EdgeInsets.only(bottom: 10),
+          child: Text('DATE'),
+        ),
+        TextFormField(
+          readOnly: true,
+          key: Key(selectedDate.toString()),
+          initialValue: DateFormat('EEE, d MMM yyyy').format(selectedDate),
+          decoration: InputDecoration(
+            suffixIcon: IconButton(
+              splashRadius: 20,
+              icon: const Icon(
+                Icons.event,
+                color: AppColor.gray,
+              ),
+              onPressed: () async {
+                DateTime? newDate = await showDatePicker(
+                  context: context,
+                  initialDate: DateTime.now(),
+                  firstDate: widget.firstDate,
+                  lastDate: widget.lastDate,
+                  // builder: (context, child) {
+                  //   return Theme(
+                  //     child: child!,
+                  //     data: ThemeData(
+                  //       colorScheme:
+                  //           ColorScheme.light(primary: AppColor.secondary),
+                  //     ),
+                  //   );
+                  // },
+                );
+                if (newDate != null) {
+                  setState(
+                    () {
+                      selectedDate = newDate;
+                    },
+                  );
+                }
+              },
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/views/widgets/date_field.dart
+++ b/lib/views/widgets/date_field.dart
@@ -18,6 +18,32 @@ class DateField extends StatefulWidget {
 class _DateFieldState extends State<DateField> {
   DateTime selectedDate = DateTime.now();
 
+  getDateInput() async {
+    DateTime? newDate = await showDatePicker(
+      context: context,
+      initialDate: selectedDate,
+      firstDate: widget.firstDate,
+      lastDate: widget.lastDate,
+      builder: (context, child) {
+        return Theme(
+          data: ThemeData(
+            colorScheme: const ColorScheme.light(
+              primary: AppColor.secondary,
+            ),
+          ),
+          child: child!,
+        );
+      },
+    );
+    if (newDate != null) {
+      setState(
+        () {
+          selectedDate = newDate;
+        },
+      );
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Column(
@@ -29,40 +55,13 @@ class _DateFieldState extends State<DateField> {
         ),
         TextFormField(
           readOnly: true,
-          key: Key(selectedDate.toString()),
+          key: UniqueKey(),
+          onTap: getDateInput,
           initialValue: DateFormat('EEE, d MMM yyyy').format(selectedDate),
-          decoration: InputDecoration(
-            suffixIcon: IconButton(
-              splashRadius: 20,
-              icon: const Icon(
-                Icons.event,
-                color: AppColor.gray,
-              ),
-              onPressed: () async {
-                DateTime? newDate = await showDatePicker(
-                  context: context,
-                  initialDate: DateTime.now(),
-                  firstDate: widget.firstDate,
-                  lastDate: widget.lastDate,
-                  builder: (context, child) {
-                    return Theme(
-                      child: child!,
-                      data: ThemeData(
-                        colorScheme: ColorScheme.light(
-                          primary: AppColor.secondary,
-                        ),
-                      ),
-                    );
-                  },
-                );
-                if (newDate != null) {
-                  setState(
-                    () {
-                      selectedDate = newDate;
-                    },
-                  );
-                }
-              },
+          decoration: const InputDecoration(
+            suffixIcon: Icon(
+              Icons.event,
+              color: AppColor.gray,
             ),
           ),
         ),

--- a/lib/views/widgets/date_field.dart
+++ b/lib/views/widgets/date_field.dart
@@ -3,10 +3,12 @@ import 'package:intl/intl.dart';
 import 'package:sun_flutter_capstone/consts/global_style.dart';
 
 class DateField extends StatefulWidget {
+  String? label;
   final DateTime firstDate;
   final DateTime lastDate;
   DateField({
     Key? key,
+    this.label,
     required this.firstDate,
     required this.lastDate,
   }) : super(key: key);
@@ -44,15 +46,22 @@ class _DateFieldState extends State<DateField> {
     }
   }
 
+  addLabel() {
+    if(widget.label != null) {
+      return Padding(
+          padding: EdgeInsets.only(bottom: 10),
+          child: Text('${widget.label}'),
+        );
+    }
+    return const SizedBox();
+  }
+
   @override
   Widget build(BuildContext context) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const Padding(
-          padding: EdgeInsets.only(bottom: 10),
-          child: Text('DATE'),
-        ),
+        addLabel(),
         TextFormField(
           readOnly: true,
           key: UniqueKey(),

--- a/lib/views/widgets/date_field.dart
+++ b/lib/views/widgets/date_field.dart
@@ -15,11 +15,11 @@ class DateField extends StatefulWidget {
   State<DateField> createState() => _DateFieldState();
 }
 
-class _DateFieldState extends State<DateField> {  
+class _DateFieldState extends State<DateField> {
   DateTime selectedDate = DateTime.now();
 
   @override
-  Widget build(BuildContext context) {    
+  Widget build(BuildContext context) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -44,15 +44,16 @@ class _DateFieldState extends State<DateField> {
                   initialDate: DateTime.now(),
                   firstDate: widget.firstDate,
                   lastDate: widget.lastDate,
-                  // builder: (context, child) {
-                  //   return Theme(
-                  //     child: child!,
-                  //     data: ThemeData(
-                  //       colorScheme:
-                  //           ColorScheme.light(primary: AppColor.secondary),
-                  //     ),
-                  //   );
-                  // },
+                  builder: (context, child) {
+                    return Theme(
+                      child: child!,
+                      data: ThemeData(
+                        colorScheme: ColorScheme.light(
+                          primary: AppColor.secondary,
+                        ),
+                      ),
+                    );
+                  },
                 );
                 if (newDate != null) {
                   setState(

--- a/lib/views/widgets/template.dart
+++ b/lib/views/widgets/template.dart
@@ -55,15 +55,12 @@ class Template extends StatelessWidget {
             ),
           ),
           SafeArea(
-            //child: Expanded(
-              //flex: 1,
-              child: Container(
-                alignment: Alignment.topLeft,
-                padding:
-                    const EdgeInsets.symmetric(vertical: 100, horizontal: 15),
-                child: content,
-              ),
-            //),
+            child: Container(
+              child: content,
+              alignment: Alignment.topLeft,
+              padding:
+                  const EdgeInsets.symmetric(vertical: 100, horizontal: 15),
+            ),
           ),
         ],
       ),

--- a/lib/views/widgets/template.dart
+++ b/lib/views/widgets/template.dart
@@ -8,7 +8,6 @@ class Template extends StatelessWidget {
   final Widget appbarTitle;
   final bool isTitleCenter;
   final List<Widget> appbarActions;
-  //[modifier] [datatype] [varname]
 
   const Template({
     Key? key,
@@ -56,15 +55,15 @@ class Template extends StatelessWidget {
             ),
           ),
           SafeArea(
-            child: Expanded(
-              flex: 1,
+            //child: Expanded(
+              //flex: 1,
               child: Container(
                 alignment: Alignment.topLeft,
                 padding:
                     const EdgeInsets.symmetric(vertical: 100, horizontal: 15),
                 child: content,
               ),
-            ),
+            //),
           ),
         ],
       ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -242,13 +242,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.2"
-  git_hooks:
-    dependency: "direct dev"
-    description:
-      name: git_hooks
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.1.6"
   glob:
     dependency: transitive
     description:
@@ -291,6 +284,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.0.0"
+  intl:
+    dependency: "direct main"
+    description:
+      name: intl
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.17.0"
   io:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -242,6 +242,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.2"
+  git_hooks:
+    dependency: "direct dev"
+    description:
+      name: git_hooks
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.6"
   glob:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,27 +4,26 @@ description: Sun Asterisk Flutter Capstone
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.16.2 <3.0.0"
+  sdk: '>=2.16.2 <3.0.0'
 
 dependencies:
+  auto_route: ^3.2.4
+  cupertino_icons: ^1.0.2
   flutter:
     sdk: flutter
-
-  cupertino_icons: ^1.0.2
-  auto_route: ^3.2.4
   hooks_riverpod: ^1.0.3
+  intl: ^0.17.0
 
 dev_dependencies:
-  flutter_test:
-    sdk: flutter
-
-  flutter_lints: ^1.0.0
   auto_route_generator: ^3.2.3
   build_runner: ^2.1.10
   git_hooks: ^0.1.6
 
-flutter:
+  flutter_lints: ^1.0.0
+  flutter_test:
+    sdk: flutter
 
+flutter:
   uses-material-design: true
 
   assets:


### PR DESCRIPTION
## Related Links:
- [Issue link](https://www.notion.so/Implement-reusable-Date-field-61dcedf78966438583f8bf694aebaa2e)

## Definition of Done
- [x] default date selected should be current date
- [x]  must have date icon
- [x]  can receive date range for first and last date
- [x] label should be optional

## Notes:
- removed Expanded child inside SafeArea due to error seen in debug console: [Incorrect use of ParentDataWidget](https://stackoverflow.com/questions/54905388/incorrect-use-of-parent-data-widget-expanded-widgets-must-be-placed-inside-flex).

## Screenshots
![image](https://user-images.githubusercontent.com/86587091/164370555-40417585-bd2d-4d46-926a-585ccaebe441.png)
![image](https://user-images.githubusercontent.com/86587091/164370593-575670ce-5a16-405e-871f-eee6a2beec88.png)
![image](https://user-images.githubusercontent.com/86587091/164370620-65da6e46-1c07-40bd-bbd8-5ac2e34247d6.png)

## Test View  Points
- [x] date field should appear in sample page after clicking "go to sample page" button in home page
- [x] date picker should appear when input field is clicked
- [x] date in text field must change to selected date
- [x]  input field should not be editable, date can only be changed by clicking on the input field 