### PR TITLE
Implement UI for Account Settings Screen

### DIFF
--- a/lib/utils/routes/router.dart
+++ b/lib/utils/routes/router.dart
@@ -1,5 +1,5 @@
 import 'package:auto_route/auto_route.dart';
-import 'package:sun_flutter_capstone/views/pages/account_settings.dart';
+import 'package:sun_flutter_capstone/views/pages/account_settings/account_settings.dart';
 import 'package:sun_flutter_capstone/views/pages/dashboard.dart';
 import 'package:sun_flutter_capstone/views/pages/notifications.dart';
 import 'package:sun_flutter_capstone/views/pages/transactions.dart';
@@ -28,7 +28,7 @@ import 'package:sun_flutter_capstone/views/widgets/navigation/bottom_navbar.dart
       AutoRoute(
         path: 'account_settings',
         name: 'SettingsRouter',
-        page: AccountSettingsPage,
+        page: AccountSettings,
       ),
     ],
   ),

--- a/lib/utils/routes/router.gr.dart
+++ b/lib/utils/routes/router.gr.dart
@@ -13,7 +13,7 @@
 import 'package:auto_route/auto_route.dart' as _i6;
 import 'package:flutter/material.dart' as _i7;
 
-import '../../views/pages/account_settings.dart' as _i5;
+import '../../views/pages/account_settings/account_settings.dart' as _i5;
 import '../../views/pages/dashboard.dart' as _i2;
 import '../../views/pages/notifications.dart' as _i4;
 import '../../views/pages/transactions.dart' as _i3;
@@ -43,7 +43,7 @@ class AppRouter extends _i6.RootStackRouter {
     },
     SettingsRouter.name: (routeData) {
       return _i6.MaterialPageX<dynamic>(
-          routeData: routeData, child: const _i5.AccountSettingsPage());
+          routeData: routeData, child: const _i5.AccountSettings());
     }
   };
 

--- a/lib/views/pages/account_settings/account_settings.dart
+++ b/lib/views/pages/account_settings/account_settings.dart
@@ -1,0 +1,174 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:sun_flutter_capstone/views/widgets/template.dart';
+import 'package:sun_flutter_capstone/views/widgets/cards/elevated_card.dart';
+import 'package:sun_flutter_capstone/views/widgets/rounded_background.dart';
+import 'package:sun_flutter_capstone/consts/global_style.dart';
+
+class AccountSettings extends HookConsumerWidget {
+  const AccountSettings({Key? key}) : super(key: key);
+
+  final String firstName = 'Juan Dela';
+  final String lastName = 'Dela Cruz';
+  final String email = 'juan.delacruz@com.com';
+  final String currency = 'PHP (₱)';
+  final String spendingLimit = '18,000';
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+
+    return Template(
+        appbarTitle: Text(
+          'Account Settings',
+          style: TextStyle(fontSize: 18, color: AppColor.secondary),
+        ),
+        content: RoundedBackground(
+          content: Container(
+            padding: const EdgeInsets.symmetric(vertical: 39, horizontal: 15),
+            child: Column(
+              children: [
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: <Widget>[
+                    IconButton(
+                      icon: const Icon(Icons.edit),
+                      onPressed: () {},
+                      color: Colors.transparent,
+                    ),
+                    Text(
+                      '$firstName $lastName',
+                      style:
+                          TextStyle(fontSize: 20, fontWeight: FontWeight.w600),
+                    ),
+                    IconButton(
+                      icon: const Icon(Icons.edit),
+                      onPressed: () {
+                        print('clicked');
+                      },
+                      color: AppColor.lightGray,
+                      iconSize: 15.0,
+                      alignment: Alignment.centerLeft,
+                      padding: EdgeInsets.all(5.0),
+                    ),
+                  ],
+                ),
+                Text(
+                  email,
+                  style: TextStyle(
+                    fontSize: 14,
+                    color: AppColor.secondary,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+                ElevatedCard(
+                  width: 344.0,
+                  content: Row(
+                    children: [
+                      Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            'Currency',
+                            style: TextStyle(
+                              fontSize: 12,
+                              fontWeight: FontWeight.w500,
+                              color: AppColor.lightGray,
+                            ),
+                          ),
+                          Text(
+                            currency,
+                            style: TextStyle(
+                              fontSize: 18,
+                              fontWeight: FontWeight.w600,
+                              height: 1.8,
+                            ),
+                          ),
+                        ],
+                      ),
+                      Spacer(),
+                      IconButton(
+                        icon: const Icon(Icons.edit),
+                        onPressed: () {
+                          print('clicked');
+                        },
+                        color: AppColor.lightGray,
+                        iconSize: 15.0,
+                        alignment: Alignment.centerRight,
+                        padding: EdgeInsets.all(0.0),
+                      ),
+                    ],
+                  ),
+                ),
+                ElevatedCard(
+                  width: 344.0,
+                  content: Row(
+                    children: [
+                      Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            'This month\'s spending limit',
+                            style: TextStyle(
+                              fontSize: 12,
+                              fontWeight: FontWeight.w500,
+                              color: AppColor.lightGray,
+                            ),
+                          ),
+                          Text(
+                            '$currency $spendingLimit',
+                            style: TextStyle(
+                              fontSize: 18,
+                              fontWeight: FontWeight.w600,
+                              height: 1.8,
+                            ),
+                          ),
+                        ],
+                      ),
+                      Spacer(),
+                      IconButton(
+                        icon: const Icon(Icons.edit),
+                        onPressed: () {
+                          print('clicked');
+                        },
+                        color: AppColor.lightGray,
+                        iconSize: 15.0,
+                        alignment: Alignment.centerRight,
+                        padding: EdgeInsets.all(0.0),
+                      ),
+                    ],
+                  ),
+                ),
+                ElevatedCard(
+                  width: 344.0,
+                  content: Row(
+                    children: [
+                      Container(
+                        alignment: Alignment.centerLeft,
+                        child: Text(
+                          'Logout',
+                          style: TextStyle(
+                            fontSize: 18,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                      ),
+                      Spacer(),
+                      IconButton(
+                        icon: const Icon(Icons.power_settings_new_outlined),
+                        onPressed: () {
+                          print('clicked');
+                        },
+                        iconSize: 20.0,
+                        alignment: Alignment.centerRight,
+                        padding: EdgeInsets.all(0.0),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        )
+    );
+  }
+}

--- a/lib/views/pages/dashboard.dart
+++ b/lib/views/pages/dashboard.dart
@@ -5,11 +5,10 @@ import 'package:sun_flutter_capstone/consts/routes.dart';
 import 'package:sun_flutter_capstone/state/session_provider.dart';
 import 'package:sun_flutter_capstone/utils/routing.dart';
 import 'package:sun_flutter_capstone/views/widgets/buttons/filled_button_text.dart';
+import 'package:sun_flutter_capstone/views/widgets/buttons/outline_button_text.dart';
 import 'package:sun_flutter_capstone/views/widgets/template.dart';
-
 class Dashboard extends HookConsumerWidget {
   const Dashboard({Key? key}) : super(key: key);
-
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final user = ref.watch(sessionProvider);
@@ -33,6 +32,19 @@ class Dashboard extends HookConsumerWidget {
             FilledButtonText(
               text: 'Go To Notifications Page',
               onPressed: () => {navigateTo(context, Routes.notifications)},
+            ),
+            OutlinedButtonText(
+              text: 'Outlined Pink',
+              color: AppColor.pink,
+              onPressed: () => {},
+            ),
+            OutlinedButtonText(
+              text: 'Outlined Blue',
+              onPressed: () => {},
+            ),
+            ElevatedButton(
+              onPressed: () => {navigateTo(context, '/account_settings')},
+              child: const Text('Go To Settings'),
             ),
             Visibility(
               visible: user.username != 'User',

--- a/lib/views/widgets/cards/elevated_card.dart
+++ b/lib/views/widgets/cards/elevated_card.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+
+class ElevatedCard extends StatelessWidget {
+  final Widget content;
+  final double width;
+
+  const ElevatedCard({
+    Key? key,
+    required this.content,
+    required this.width,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: width,
+      margin: const EdgeInsets.only(top: 25.0),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.all(
+            Radius.circular(20.0) //                 <--- border radius here
+            ),
+        color: Colors.white,
+        boxShadow: const [
+          BoxShadow(
+            color: Color(0xFFEDEDED),
+            blurRadius: 4,
+            offset: Offset(0, 4), // changes position of shadow
+          ),
+        ],
+      ),
+      child: Container(
+        padding: const EdgeInsets.symmetric(vertical: 15, horizontal: 30),
+        child: content,
+      ),
+    );
+  }
+}

--- a/lib/views/widgets/rounded_background.dart
+++ b/lib/views/widgets/rounded_background.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+
+class RoundedBackground extends StatelessWidget {
+  final Widget content;
+
+  const RoundedBackground({
+    Key? key,
+    required this.content,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.only(top: 40.0),
+      decoration: const BoxDecoration(
+        borderRadius: BorderRadius.only(
+          topRight: Radius.circular(30.0),
+          topLeft: Radius.circular(30.0),
+        ),
+        color: Colors.white,
+      ),
+      alignment: Alignment.center,
+      child: content,
+    );
+  }
+}

--- a/lib/views/widgets/template.dart
+++ b/lib/views/widgets/template.dart
@@ -65,8 +65,8 @@ class Template extends StatelessWidget {
               ),
             ),
           ],
+          ),
         ),
-      ),
-    );
+      );
   }
 }


### PR DESCRIPTION
## Related Links:

## Definition of Done
- [ ]  Display important information: Name, email, currency, spending limit info, logout area
- [ ]  Please consider dynamic placeholder for each info, since it will be updated later once we have data handling
- [ ]  The edit icon itself must be clickable

## Notes:
- Icons are clickable but it will only print a word 'Clicked'.
- Navigation from home page to account settings also added here. Navigate by clicking **Go to Settings** button


## Screenshots
![image](https://user-images.githubusercontent.com/97145763/164440211-67db6e72-24a3-4f09-92e1-61867d700e28.png)


## Test View  Points
- [ ] N/A
