### PR TITLE
[UI] Implemented tab layout with dynamic content

### DIFF
--- a/lib/consts/global_style.dart
+++ b/lib/consts/global_style.dart
@@ -6,8 +6,8 @@ class AppColor {
   static const Color secondary = Color(0xFF324ED9);
   static const Color lightGray = Color(0xFFA7ABB8);
   static const Color gray = Color(0xFF666666);
+  static const Color onyx = Color(0xFF3D3541);
   static const Color darkBlue = Color(0xFF242D58);
-  static const Color onyx = Color(0xFF242D58);
   static const Color red = Color(0xFFD93232);
   static const Color pink = Color(0xFFFE91A7);
   static const Color rose = Color(0xFFAD707C);

--- a/lib/views/pages/transactions.dart
+++ b/lib/views/pages/transactions.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:sun_flutter_capstone/state/spending_provider.dart';
+import 'package:sun_flutter_capstone/consts/global_style.dart';
+import 'package:sun_flutter_capstone/views/widgets/tabs/tab_layout.dart';
 import 'package:sun_flutter_capstone/views/widgets/template.dart';
 
 class TransactionsPage extends HookConsumerWidget {
@@ -8,10 +9,22 @@ class TransactionsPage extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final spendingAmount = ref.watch(spendingProvider);
-    return const Template(
+    return Template(
       appbarTitle: Text('Transactions Page'),
-      content: Center(child: Text('sample content')),
+      content: Center(
+        child: TabLayout(
+          firstTab: Container(
+            color: AppColor.pink,
+            alignment: Alignment.center,
+            child: Text('Expense content'),
+          ),
+          secondTab: Container(
+            color: AppColor.light,
+            alignment: Alignment.center,
+            child: Text('Income content'),
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/views/widgets/tabs/tab_buttons.dart
+++ b/lib/views/widgets/tabs/tab_buttons.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:sun_flutter_capstone/consts/global_style.dart';
+
+class TabButtons extends StatelessWidget {
+  final TabController tabController;
+  final int index;
+
+  const TabButtons({
+    Key? key,
+    required this.tabController,
+    required this.index,
+  }) : super(key: key);
+
+  
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 50,
+      decoration: BoxDecoration(
+        color: AppColor.light,
+        borderRadius: BorderRadius.circular(
+          25.0,
+        ),
+      ),
+      child: Expanded(
+        child: Padding(
+          padding: const EdgeInsets.all(5),
+          child: TabBar(
+            controller: tabController,
+            indicator: BoxDecoration(
+              borderRadius: BorderRadius.circular(
+                25.0,
+              ),
+              color: index == 0 ? AppColor.pink : AppColor.darkBlue,
+            ),
+            unselectedLabelColor: AppColor.darkBlue,
+            labelColor: Colors.white,
+            labelStyle: TextStyle(fontWeight: FontWeight.w600),
+            tabs: const [
+              Tab(
+                child: Text('Add Expense'),
+              ),
+              Tab(
+                child: Text('Add Income'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/widgets/tabs/tab_layout.dart
+++ b/lib/views/widgets/tabs/tab_layout.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:sun_flutter_capstone/views/widgets/tabs/tab_buttons.dart';
+
+class TabLayout extends StatefulWidget {
+  final Widget firstTab;
+  final Widget secondTab;
+
+  const TabLayout({
+    Key? key,
+    required this.firstTab,
+    required this.secondTab,
+  }) : super(key: key);
+
+  @override
+  State<TabLayout> createState() => _TabLayoutState();
+}
+
+class _TabLayoutState extends State<TabLayout>
+    with SingleTickerProviderStateMixin {
+  late TabController _tabController;
+  int index = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(vsync: this, length: 2);
+    _tabController.addListener(() {
+      setState(() {
+        index = _tabController.index;
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: EdgeInsets.symmetric(vertical: 30, horizontal: 28),
+      child: Column(
+        children: [
+          //? FOR TAB BUTTONS
+          TabButtons(
+            tabController: _tabController,
+            index: index,
+          ),
+          //? FOR CONTENT
+          Expanded(
+            child: Container(
+              margin: EdgeInsets.only(top: 20),
+              child: TabBarView(
+                controller: _tabController,
+                children: [widget.firstTab, widget.secondTab],
+              ),
+            ),
+          )
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Related Links:
- [Issue link](https://www.notion.so/Transaction-Implement-UI-for-tab-switch-631ee894334842298b4ee18586b7bc8f)

## Definition of Done
- [x]  When Expense form is shown, tab must be in secondary bg (pink)
- [x]  When Income form is shown, tab must be in dark blue bg
- [x]  Display the empty screen for each tab

## Notes:
- changes made to global_style.dart was due to darkBlue and onyx being interchanged
- no behavior yet for floating action button, tab layout is placed in Transactions page

## Screenshots
![image](https://user-images.githubusercontent.com/86587091/165049456-f958bb77-0956-4dbd-98b5-66422f366de4.png)
![image](https://user-images.githubusercontent.com/86587091/165049475-054f45f1-2d19-4804-b40d-98b41934c92a.png)

## Test View  Points
- [x] tab layout should be seen in transactions page
- [x] should show different content per tab
- [x] tab colors should be different
