### PR TITLE
[Dashboard] Implement UI for the spending limit percentage section

### DIFF
--- a/lib/consts/global_style.dart
+++ b/lib/consts/global_style.dart
@@ -86,6 +86,6 @@ ElevatedButtonThemeData elevatedButtonTheme = ElevatedButtonThemeData(
 );
 
 class ProgressBarTheme {
-  static const Color barColor = Color(0xFFFE91A7);
+  static const Color barColor = AppColor.pink;
   static const Color bgColor = Color(0xFFF0F6F5);
 }

--- a/lib/consts/global_style.dart
+++ b/lib/consts/global_style.dart
@@ -84,3 +84,8 @@ ElevatedButtonThemeData elevatedButtonTheme = ElevatedButtonThemeData(
     ),
   ),
 );
+
+class ProgressBarTheme {
+  static const Color barColor = Color(0xFFFE91A7);
+  static const Color bgColor = Color(0xFFF0F6F5);
+}

--- a/lib/state/spending_provider.dart
+++ b/lib/state/spending_provider.dart
@@ -1,0 +1,7 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+final spendingProvider = StateProvider((_) => 0.75);
+
+void setSpendingAmount(WidgetRef ref, double amount) {
+  ref.read(spendingProvider.state).update((state) => amount);
+}

--- a/lib/views/pages/dashboard.dart
+++ b/lib/views/pages/dashboard.dart
@@ -69,10 +69,15 @@ class _DashboardState extends ConsumerState<Dashboard> {
                 totalExpenses: widget.totalExpenses,
                 currency: widget.currency,
               ),
-              ProgressBar(
-                progress: spendingAmount,
-                label: "You have spent",
+              Container(
+                margin:
+                    EdgeInsets.only(top: 35, left: 20, right: 20, bottom: 10),
+                child: ProgressBar(
+                  progress: spendingAmount,
+                  label: "You have spent",
+                ),
               ),
+              // * The following row can be removed this is just for testing the progress bar
               Row(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
@@ -94,14 +99,6 @@ class _DashboardState extends ConsumerState<Dashboard> {
                     ),
                   )
                 ],
-              ),
-              FilledButtonText(
-                text: 'Go To Notifications Page',
-                onPressed: () => {navigateTo(context, Routes.notifications)},
-              ),
-              ElevatedButton(
-                onPressed: () => {navigateTo(context, '/account_settings')},
-                child: const Text('Go To Settings'),
               ),
             ],
           ),

--- a/lib/views/pages/dashboard.dart
+++ b/lib/views/pages/dashboard.dart
@@ -3,14 +3,18 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:sun_flutter_capstone/consts/global_style.dart';
 import 'package:sun_flutter_capstone/consts/routes.dart';
 import 'package:sun_flutter_capstone/state/session_provider.dart';
+import 'package:sun_flutter_capstone/state/spending_provider.dart';
 import 'package:sun_flutter_capstone/utils/routing.dart';
 import 'package:sun_flutter_capstone/views/widgets/buttons/filled_button_text.dart';
 import 'package:sun_flutter_capstone/views/widgets/buttons/outline_button_text.dart';
+import 'package:sun_flutter_capstone/views/widgets/progress_bar.dart';
 import 'package:sun_flutter_capstone/views/widgets/template.dart';
 import 'package:sun_flutter_capstone/views/pages/transaction_summary.dart';
 
-class Dashboard extends HookConsumerWidget {
-  const Dashboard({Key? key}) : super(key: key);
+class Dashboard extends StatefulHookConsumerWidget {
+  const Dashboard({
+    Key? key,
+  }) : super(key: key);
 
   final String firstName = 'Juan Dela';
   final String lastName = 'Dela Cruz';
@@ -29,18 +33,25 @@ class Dashboard extends HookConsumerWidget {
   }
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<ConsumerStatefulWidget> createState() => _DashboardState();
+}
+
+class _DashboardState extends ConsumerState<Dashboard> {
+  @override
+  Widget build(BuildContext context) {
     final user = ref.watch(sessionProvider);
+    final spendingAmount = ref.watch(spendingProvider);
+
     return Template(
       appbarTitle: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text(
-            _greeting(),
+            widget._greeting(),
             style: TextStyle(color: AppColor.gray, fontSize: 14),
           ),
           Text(
-            '$firstName $lastName',
+            '${widget.firstName} ${widget.lastName}',
             style: TextStyle(color: AppColor.secondary, fontSize: 20),
           ),
         ],
@@ -48,39 +59,52 @@ class Dashboard extends HookConsumerWidget {
       isTitleCenter: false,
       content: Container(
         alignment: Alignment.center,
-        child: Column(
-          children: [
-            TransactionSummary(
-              totalBalance: totalIncome - totalExpenses,
-              totalIncome: totalIncome,
-              totalExpenses: totalExpenses,
-              currency: currency,
-            ),
-            FilledButtonText(
-              text: 'Go To Notifications Page',
-              onPressed: () => {navigateTo(context, Routes.notifications)},
-            ),
-            OutlinedButtonText(
-              text: 'Outlined Pink',
-              color: AppColor.pink,
-              onPressed: () => {},
-            ),
-            OutlinedButtonText(
-              text: 'Outlined Blue',
-              onPressed: () => {},
-            ),
-            ElevatedButton(
-              onPressed: () => {navigateTo(context, '/account_settings')},
-              child: const Text('Go To Settings'),
-            ),
-            Visibility(
-              visible: user.username != 'User',
-              child: ElevatedButton(
-                onPressed: () => logout(ref),
-                child: const Text('Logout'),
+        child: Container(
+          margin: EdgeInsets.symmetric(horizontal: 10.0),
+          child: Column(
+            children: [
+              TransactionSummary(
+                totalBalance: widget.totalIncome - widget.totalExpenses,
+                totalIncome: widget.totalIncome,
+                totalExpenses: widget.totalExpenses,
+                currency: widget.currency,
               ),
-            )
-          ],
+              ProgressBar(
+                progress: spendingAmount,
+                label: "You have spent",
+              ),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Flexible(
+                    child: ElevatedButton(
+                      onPressed: () {
+                        setSpendingAmount(ref, spendingAmount - 0.1);
+                      },
+                      child: const Text('-'),
+                    ),
+                  ),
+                  const SizedBox(width: 30),
+                  Flexible(
+                    child: ElevatedButton(
+                      onPressed: () {
+                        setSpendingAmount(ref, spendingAmount + 0.1);
+                      },
+                      child: const Text('+'),
+                    ),
+                  )
+                ],
+              ),
+              FilledButtonText(
+                text: 'Go To Notifications Page',
+                onPressed: () => {navigateTo(context, Routes.notifications)},
+              ),
+              ElevatedButton(
+                onPressed: () => {navigateTo(context, '/account_settings')},
+                child: const Text('Go To Settings'),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/views/pages/transactions.dart
+++ b/lib/views/pages/transactions.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:sun_flutter_capstone/state/session_provider.dart';
-import 'package:sun_flutter_capstone/utils/routing.dart';
+import 'package:sun_flutter_capstone/state/spending_provider.dart';
 import 'package:sun_flutter_capstone/views/widgets/template.dart';
 
 class TransactionsPage extends HookConsumerWidget {
@@ -9,11 +8,10 @@ class TransactionsPage extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final spendingAmount = ref.watch(spendingProvider);
     return const Template(
       appbarTitle: Text('Transactions Page'),
-      content: Center(
-        child: Text('Sample Content'),
-      ),
+      content: Center(child: Text('sample content')),
     );
   }
 }

--- a/lib/views/widgets/progress_bar.dart
+++ b/lib/views/widgets/progress_bar.dart
@@ -1,0 +1,144 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:sun_flutter_capstone/consts/global_style.dart';
+
+class ProgressBar extends StatefulHookConsumerWidget {
+  double progress;
+  String? label;
+  final Color barColor;
+  final Color bgColor;
+  final double barSize;
+  final String barFontFamily;
+  final double barFontSize;
+  final double barRadius;
+
+  ProgressBar({
+    Key? key,
+    this.progress = 0,
+    this.label,
+    this.barColor = ProgressBarTheme.barColor,
+    this.bgColor = ProgressBarTheme.bgColor,
+    this.barSize = 25.0,
+    this.barFontFamily = 'Inter',
+    this.barFontSize = 14,
+    this.barRadius = 8,
+  }) : super(key: key);
+
+  @override
+  ConsumerState<ConsumerStatefulWidget> createState() => _ProgressBarState();
+}
+
+class _ProgressBarState extends ConsumerState<ProgressBar>
+    with TickerProviderStateMixin {
+  late AnimationController controller;
+
+  @override
+  void initState() {
+    controller = AnimationController(
+      vsync: this,
+      duration: const Duration(seconds: 5),
+    )..addListener(() {
+        setState(() {});
+      });
+    controller.animateTo(
+      widget.progress,
+      duration: const Duration(milliseconds: 500),
+    );
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+  }
+
+  void updateProgress(double newValue) {
+    controller.animateTo(
+      newValue,
+      duration: const Duration(milliseconds: 500),
+      curve: Curves.fastLinearToSlowEaseIn,
+    );
+  }
+
+  List<Text> getPercentValues(double progress) {
+    double fillValue = progress * 100;
+    return [
+      styleText(doubleToPercent(fillValue), true),
+      styleText(doubleToPercent(100 - fillValue), false),
+    ];
+  }
+
+  Text styleText(String text, bool light) {
+    return Text(
+      text,
+      style: TextStyle(
+        fontFamily: widget.barFontFamily,
+        fontSize: widget.barFontSize,
+        fontWeight: FontWeight.bold,
+        color: (light) ? Colors.white : AppColor.onyx,
+      ),
+    );
+  }
+
+  String doubleToPercent(double value) {
+    return value <= 0 ? "0 %" : value.toStringAsFixed(2) + "%";
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.start,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Visibility(
+          child: Text(
+            widget.label ?? '',
+            textAlign: TextAlign.start,
+            style: const TextStyle(
+              color: AppColor.onyx,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ),
+        const SizedBox(height: 4),
+        Stack(
+          children: <Widget>[
+            ClipRRect(
+              borderRadius: BorderRadius.all(Radius.circular(widget.barRadius)),
+              child: AnimatedBuilder(
+                animation: controller,
+                builder: (BuildContext context, _) {
+                  updateProgress(widget.progress);
+                  return LayoutBuilder(
+                    // Used to get the parent width
+                    builder: (
+                      BuildContext context,
+                      BoxConstraints constraints,
+                    ) {
+                      return Container(
+                        width: constraints.maxWidth * controller.value,
+                        height: widget.barSize,
+                        color: widget.barColor,
+                      );
+                    },
+                  );
+                },
+              ),
+            ),
+            Container(
+              height: widget.barSize,
+              margin: const EdgeInsets.symmetric(
+                horizontal: 10.0,
+              ),
+              child: Flex(
+                direction: Axis.horizontal,
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: getPercentValues(widget.progress),
+              ),
+            )
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/lib/views/widgets/progress_bar.dart
+++ b/lib/views/widgets/progress_bar.dart
@@ -3,8 +3,8 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:sun_flutter_capstone/consts/global_style.dart';
 
 class ProgressBar extends StatefulHookConsumerWidget {
-  double progress;
   String? label;
+  final double progress;
   final Color barColor;
   final Color bgColor;
   final double barSize;


### PR DESCRIPTION
## Related Links:
- [Issue link](https://www.notion.so/Dashboard-Implement-UI-for-the-spending-limit-percentage-section-93a44a5deca9416fabbab6bec2d260f2)

## Definition of Done
- [ ]  Display program bar for spending limit
    - Make the percentage bar reusable, with dynamic fields
- [ ]  Display text above the program bar
- [ ]  Used FE91A7 hex color if user already start adding expense
- [ ]  User F0F6F5 hex color if user not yet start adding expense
- [ ]  Default percentage is 100% with the grey F0F6F5 hex color

## Notes:
- N/A


## Screenshots
![image](https://user-images.githubusercontent.com/95011977/164684434-5e561d67-696a-4706-885c-f7bdf95a9e0d.png)

## Test View  Points
- [ ] N/A
