### PR TITLE
[UI] Implemented Add Income UI

### DIFF
--- a/lib/views/pages/test/sample_crud.dart
+++ b/lib/views/pages/test/sample_crud.dart
@@ -58,7 +58,7 @@ class _SampleCrudState extends ConsumerState<SampleCrud> {
               InputField(
                 inputController: _amountController,
                 hintText: '0.0',
-                isNumber: true,
+                inputType: TextInputType.number,
               ),
               const SizedBox(
                 height: 20,

--- a/lib/views/pages/transactions/add_income.dart
+++ b/lib/views/pages/transactions/add_income.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'package:sun_flutter_capstone/consts/global_style.dart';
+import 'package:sun_flutter_capstone/views/widgets/buttons/outline_button_text.dart';
+import 'package:sun_flutter_capstone/views/widgets/cards/elevated_card.dart';
+import 'package:sun_flutter_capstone/views/widgets/input/date_field.dart';
+import 'package:sun_flutter_capstone/views/widgets/input/input_field.dart';
+import 'package:sun_flutter_capstone/views/widgets/input/input_group.dart';
+
+class AddIncomeForm extends StatefulWidget {
+  AddIncomeForm({Key? key}) : super(key: key);
+
+  @override
+  State<AddIncomeForm> createState() => _AddIncomeFormState();
+}
+
+class _AddIncomeFormState extends State<AddIncomeForm> {
+  final incomeFormKey = GlobalKey<FormState>();
+
+  Map<String, TextEditingController> formInputControllers = {
+    'nameController': TextEditingController(),
+    'amountController': TextEditingController(),
+    'dateController': TextEditingController(),
+  };
+
+  onSubmit() {
+    if (incomeFormKey.currentState!.validate()) {
+      //TODO: Add implementation for submission of form
+      showDialog(
+        context: context,
+        builder: (BuildContext context) => AlertDialog(
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('Name: ${formInputControllers['nameController']!.text}'),
+              Text('Amount: ${formInputControllers['amountController']!.text}'),
+              Text('Date: ${formInputControllers['dateController']!.text}'),
+            ],
+          ),
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ElevatedCard(
+      width: double.infinity,
+      margin: 0,
+      padding: const EdgeInsets.symmetric(horizontal: 25, vertical: 40),
+      content: Form(
+        key: incomeFormKey,
+        child: SingleChildScrollView(
+          child: Column(
+            children: [
+              InputGroup(
+                label: 'NAME',
+                input: InputField(
+                  hintText: 'Name of income source',
+                  inputController: formInputControllers['nameController']!,
+                ),
+              ),
+              InputGroup(
+                label: 'AMOUNT',
+                input: InputField(
+                  hintText: 'How much did you earn?',
+                  inputType: TextInputType.number,
+                  inputController: formInputControllers['amountController']!,
+                ),
+              ),
+              InputGroup(
+                label: 'DATE',
+                input: DateField(
+                  firstDate: DateTime(DateTime.now().year, 1),
+                  lastDate: DateTime.now(),
+                  dateController: formInputControllers['dateController']!,
+                ),
+              ),
+              OutlinedButtonText(
+                onPressed: onSubmit,
+                text: 'Save Income',
+                color: AppColor.secondary,
+              )
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/pages/transactions/add_transaction.dart
+++ b/lib/views/pages/transactions/add_transaction.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:sun_flutter_capstone/consts/global_style.dart';
 import 'package:sun_flutter_capstone/views/pages/transactions/add_expense.dart';
+import 'package:sun_flutter_capstone/views/pages/transactions/add_income.dart';
 import 'package:sun_flutter_capstone/views/widgets/tabs/tab_layout.dart';
 import 'package:sun_flutter_capstone/views/widgets/template.dart';
 
@@ -14,11 +15,7 @@ class AddTransaction extends StatelessWidget {
       appbarTitle: Text('Add Transaction'),
       content: TabLayout(
         firstTab: AddExpenseForm(),
-        secondTab: Container(
-          color: AppColor.light,
-          alignment: Alignment.center,
-          child: Text('Income content'),
-        ),
+        secondTab: AddIncomeForm(),
       ),
     );
   }


### PR DESCRIPTION
## Related Links:
- [Issue link](https://www.notion.so/Transaction-Implement-Add-Income-UI-74537d720ca74ebaa9157348d6d76bff)

## Definition of Done
- [ ]  Implement income form with following input fields (Name, Amount, Date)
- [ ]  Add button below all the input fields
- [ ]  Used reusable component for all the elements inside the form


## Notes:
- form is scrollable
- onSubmit can be changed

## Screenshots
![image](https://user-images.githubusercontent.com/86587091/165234129-91ea06ee-7526-48e0-937c-cf1eace48ddc.png)
![image](https://user-images.githubusercontent.com/86587091/165234160-07952b61-e2b7-4f7d-b9ba-da3947eeb368.png)
![image](https://user-images.githubusercontent.com/86587091/165234298-9cb0cda8-a42d-4067-b866-3e1b01525b3e.png)

## Test View  Points
- [ ] add transaction page should appear when floating action button is clicked
    - [ ] all fields must be provided
- [ ] show error message for empty fields
- [ ]  form must show in "Add Income" tab
- [ ]  values in dialog must match user input