### PR TITLE
[UI] Implemented transaction history tab switch

### DIFF
--- a/lib/views/pages/transactions.dart
+++ b/lib/views/pages/transactions.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:sun_flutter_capstone/consts/global_style.dart';
+import 'package:sun_flutter_capstone/views/widgets/rounded_background.dart';
 import 'package:sun_flutter_capstone/views/widgets/tabs/tab_layout.dart';
 import 'package:sun_flutter_capstone/views/widgets/template.dart';
 
@@ -10,7 +11,8 @@ class TransactionsPage extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return Template(
-        appbarTitle: Text('Transactions Page'),
+      appbarTitle: Text('Transactions Page'),
+      content: RoundedBackground(
         content: TabLayout(
           tabButtonLabels: const [
             'All',
@@ -23,40 +25,86 @@ class TransactionsPage extends HookConsumerWidget {
             AppColor.pink,
           ],
           tabContents: [
-            Container(
-              color: AppColor.darkBlue,
-              child: Center(
-                child: Text(
-                  'All content',
-                  style: TextStyle(
-                    color: Colors.white,
-                  ),
-                ),
+            Summary(
+              value: '₱ 1,840.00',
+            ),
+            Summary(
+              label: 'Total Income',
+              value: '₱ 1,840.00',
+              labelColor: AppColor.secondary,
+            ),
+            Summary(
+              label: 'Total Expense',
+              value: '₱ 1,840.00',
+              labelColor: AppColor.pink,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class Summary extends StatelessWidget {
+  final String label;
+  final String value;
+  final Color labelColor;
+  final List<Map<String, dynamic>> transactionList = [
+    {
+      'name': 'Profit',
+      'amount': 850,
+      'date': DateTime.now(),
+      'type': 'Income',
+    },
+    {
+      'name': 'Bills',
+      'amount': 1500,
+      'date': DateTime.now(),
+      'type': 'Expense',
+    },
+  ];
+
+  Summary({
+    Key? key,
+    this.label = 'Total',
+    required this.value,
+    this.labelColor = AppColor.darkBlue,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.start,
+      children: [
+        //? transaction summary 
+        Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(
+              value,
+              style: TextStyle(
+                color: AppColor.darkBlue,
+                fontWeight: FontWeight.bold,
+                fontSize: 28,
               ),
             ),
-             Container(
-              color: AppColor.secondary,
-              child: Center(
-                child: Text(
-                  'All incomes content',
-                  style: TextStyle(
-                    color: Colors.white,
-                  ),
-                ),
-              ),
-            ),
-             Container(
-              color: AppColor.pink,
-              child: Center(
-                child: Text(
-                  'All Expenses content',
-                  style: TextStyle(
-                    color: Colors.white,
-                  ),
-                ),
+            Text(
+              label,
+              style: TextStyle(
+                color: labelColor,
+                fontSize: 15,
               ),
             ),
           ],
-        ));
+        ),
+        //TODO: COMMON CONTENT HERE
+        Container(
+          margin: EdgeInsets.only(
+            top: 25,
+          ),
+          child: Text('content here'),
+        ),
+      ],
+    );
   }
 }

--- a/lib/views/pages/transactions.dart
+++ b/lib/views/pages/transactions.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:sun_flutter_capstone/consts/global_style.dart';
+import 'package:sun_flutter_capstone/views/widgets/tabs/tab_layout.dart';
 import 'package:sun_flutter_capstone/views/widgets/template.dart';
 
 class TransactionsPage extends HookConsumerWidget {
@@ -8,10 +10,53 @@ class TransactionsPage extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return Template(
-      appbarTitle: Text('Transactions Page'),
-      content: Center(
-        child: Text('Income content'),
-      ),
-    );
+        appbarTitle: Text('Transactions Page'),
+        content: TabLayout(
+          tabButtonLabels: const [
+            'All',
+            'Incomes',
+            'Expenses',
+          ],
+          tabColors: const [
+            AppColor.darkBlue,
+            AppColor.secondary,
+            AppColor.pink,
+          ],
+          tabContents: [
+            Container(
+              color: AppColor.darkBlue,
+              child: Center(
+                child: Text(
+                  'All content',
+                  style: TextStyle(
+                    color: Colors.white,
+                  ),
+                ),
+              ),
+            ),
+             Container(
+              color: AppColor.secondary,
+              child: Center(
+                child: Text(
+                  'All incomes content',
+                  style: TextStyle(
+                    color: Colors.white,
+                  ),
+                ),
+              ),
+            ),
+             Container(
+              color: AppColor.pink,
+              child: Center(
+                child: Text(
+                  'All Expenses content',
+                  style: TextStyle(
+                    color: Colors.white,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ));
   }
 }

--- a/lib/views/pages/transactions.dart
+++ b/lib/views/pages/transactions.dart
@@ -76,7 +76,7 @@ class Summary extends StatelessWidget {
     return Column(
       mainAxisAlignment: MainAxisAlignment.start,
       children: [
-        //? transaction summary 
+        // transaction summary 
         Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [

--- a/lib/views/pages/transactions/add_transaction.dart
+++ b/lib/views/pages/transactions/add_transaction.dart
@@ -14,8 +14,18 @@ class AddTransaction extends StatelessWidget {
     return Template(
       appbarTitle: Text('Add Transaction'),
       content: TabLayout(
-        firstTab: AddExpenseForm(),
-        secondTab: AddIncomeForm(),
+        tabButtonLabels: const [
+          'Add Expense',
+          'Add Income',
+        ],
+        tabColors: const [
+          AppColor.pink,
+          AppColor.darkBlue
+        ],
+        tabContents: [
+          AddExpenseForm(),
+          AddIncomeForm()
+        ],
       ),
     );
   }

--- a/lib/views/widgets/tabs/tab_buttons.dart
+++ b/lib/views/widgets/tabs/tab_buttons.dart
@@ -3,13 +3,23 @@ import 'package:sun_flutter_capstone/consts/global_style.dart';
 
 class TabButtons extends StatelessWidget {
   final TabController tabController;
-  final int index;
+  final List<String> tabButtonLabels;
+  final Color tabColor;
 
   const TabButtons({
     Key? key,
     required this.tabController,
-    required this.index,
+    required this.tabButtonLabels,
+    required this.tabColor
   }) : super(key: key);
+
+  displayButtonLabels() {
+    return tabButtonLabels.map(
+      (label) {
+        return Tab(child: Text(label));
+      },
+    ).toList();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -24,25 +34,17 @@ class TabButtons extends StatelessWidget {
       child: Padding(
         padding: const EdgeInsets.all(5),
         child: TabBar(
-          controller: tabController,
-          indicator: BoxDecoration(
-            borderRadius: BorderRadius.circular(
-              25.0,
+            controller: tabController,
+            indicator: BoxDecoration(
+              borderRadius: BorderRadius.circular(
+                25.0,
+              ),
+              color: tabColor,
             ),
-            color: index == 0 ? AppColor.pink : AppColor.darkBlue,
-          ),
-          unselectedLabelColor: Colors.black,
-          labelStyle: TextStyle(fontWeight: FontWeight.w600),
-          labelColor: Colors.white,
-          tabs: const [
-            Tab(
-              child: Text('Add Expense'),
-            ),
-            Tab(
-              child: Text('Add Income'),
-            ),
-          ],
-        ),
+            unselectedLabelColor: Colors.black,
+            labelStyle: TextStyle(fontWeight: FontWeight.w600),
+            labelColor: Colors.white,
+            tabs: displayButtonLabels()),
       ),
     );
   }

--- a/lib/views/widgets/tabs/tab_layout.dart
+++ b/lib/views/widgets/tabs/tab_layout.dart
@@ -42,7 +42,6 @@ class _TabLayoutState extends State<TabLayout>
 
   @override
   Widget build(BuildContext context) {
-    print('CURRENT TAB: ${_tabController.index}');
     return Container(
       margin: EdgeInsets.symmetric(vertical: 30, horizontal: 28),
       child: Flex(

--- a/lib/views/widgets/tabs/tab_layout.dart
+++ b/lib/views/widgets/tabs/tab_layout.dart
@@ -1,14 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:sun_flutter_capstone/views/widgets/tabs/tab_buttons.dart';
 
+// Refactor receiving of tab details if there's time
 class TabLayout extends StatefulWidget {
-  final Widget firstTab;
-  final Widget secondTab;
-
+  final List<String> tabButtonLabels;
+  final List<Color> tabColors;
+  final List<Widget> tabContents;
   const TabLayout({
     Key? key,
-    required this.firstTab,
-    required this.secondTab,
+    required this.tabButtonLabels,
+    required this.tabColors,
+    required this.tabContents,
   }) : super(key: key);
 
   @override
@@ -23,7 +25,7 @@ class _TabLayoutState extends State<TabLayout>
   @override
   void initState() {
     super.initState();
-    _tabController = TabController(vsync: this, length: 2);
+    _tabController = TabController(vsync: this, length: widget.tabContents.length);
     _tabController.addListener(() {
       setState(() {
         index = _tabController.index;
@@ -47,7 +49,9 @@ class _TabLayoutState extends State<TabLayout>
           //? FOR TAB BUTTONS
           TabButtons(
             tabController: _tabController,
-            index: index,
+            // index: index,
+            tabButtonLabels: widget.tabButtonLabels,
+            tabColor: widget.tabColors[index],
           ),
           //? FOR CONTENT
           Expanded(
@@ -55,7 +59,7 @@ class _TabLayoutState extends State<TabLayout>
               margin: EdgeInsets.only(top: 20),
               child: TabBarView(
                 controller: _tabController,
-                children: [widget.firstTab, widget.secondTab],
+                children: widget.tabContents,
               ),
             ),
           )

--- a/lib/views/widgets/tabs/tab_layout.dart
+++ b/lib/views/widgets/tabs/tab_layout.dart
@@ -25,7 +25,8 @@ class _TabLayoutState extends State<TabLayout>
   @override
   void initState() {
     super.initState();
-    _tabController = TabController(vsync: this, length: widget.tabContents.length);
+    _tabController =
+        TabController(vsync: this, length: widget.tabContents.length);
     _tabController.addListener(() {
       setState(() {
         index = _tabController.index;
@@ -41,6 +42,7 @@ class _TabLayoutState extends State<TabLayout>
 
   @override
   Widget build(BuildContext context) {
+    print('CURRENT TAB: ${_tabController.index}');
     return Container(
       margin: EdgeInsets.symmetric(vertical: 30, horizontal: 28),
       child: Flex(
@@ -49,7 +51,6 @@ class _TabLayoutState extends State<TabLayout>
           //? FOR TAB BUTTONS
           TabButtons(
             tabController: _tabController,
-            // index: index,
             tabButtonLabels: widget.tabButtonLabels,
             tabColor: widget.tabColors[index],
           ),
@@ -62,7 +63,7 @@ class _TabLayoutState extends State<TabLayout>
                 children: widget.tabContents,
               ),
             ),
-          )
+          ),
         ],
       ),
     );


### PR DESCRIPTION
## Related Links:
- [Issue link](https://www.notion.so/Transaction-History-Implement-UI-for-tab-switch-086fa638d84d42b5be96621a5f65a27c)

## Definition of Done
- [ ]  Implement UI for tab switch
- [ ]  Display different content for each tab screen
    - All — display card summary (navy blue)
    - Incomes — display card summary (accent blue)
    - Expenses — display card summary (pink),

## Notes:
- modified tab layout

## Screenshots
![image](https://user-images.githubusercontent.com/86587091/165265711-dea652b7-5194-40ff-95e4-055c88df6b08.png)
![image](https://user-images.githubusercontent.com/86587091/165265739-27ec9d71-b378-4c34-9fff-36275c52dfd3.png)
![image](https://user-images.githubusercontent.com/86587091/165265757-293663bd-8ffa-417b-b122-c04509d5a8c4.png)

## Test View  Points
- [ ] Must display all three tabs (All, Incomes, Expenses)
- [ ] Tabs must have different colors following design
- [ ] Different content must be shown for each tab
