### PR TITLE
[UI] [Account] Implement UI for Spending Limit setting

### DIFF
--- a/lib/consts/routes.dart
+++ b/lib/consts/routes.dart
@@ -6,4 +6,5 @@ class Routes {
   static const String samplecrud = '/sample_crud';
   static const String addTransaction = '/add_transaction';
   static const String updateBasicInfo = '/update_basic_info';
+  static const String spendingLimit = '/spending_limit';
 }

--- a/lib/utils/routes/router.dart
+++ b/lib/utils/routes/router.dart
@@ -1,5 +1,6 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:sun_flutter_capstone/views/pages/account_settings/account_settings.dart';
+import 'package:sun_flutter_capstone/views/pages/account_settings/spending_limit.dart';
 import 'package:sun_flutter_capstone/views/pages/dashboard.dart';
 import 'package:sun_flutter_capstone/views/pages/notifications.dart';
 import 'package:sun_flutter_capstone/views/pages/test/sample_crud.dart';
@@ -47,6 +48,11 @@ import 'package:sun_flutter_capstone/views/pages/account_settings/update_basic_i
         path: 'update_basic_info',
         name: 'UpdateBasicInfoRouter',
         page: UpdateBasicInfo,
+      ),
+      AutoRoute(
+        path: 'spending_limit',
+        name: 'SpendingLimitRouter',
+        page: SpendingLimit,
       ),
     ],
   ),

--- a/lib/utils/routes/router.gr.dart
+++ b/lib/utils/routes/router.gr.dart
@@ -10,10 +10,11 @@
 //
 // ignore_for_file: type=lint
 
-import 'package:auto_route/auto_route.dart' as _i9;
-import 'package:flutter/material.dart' as _i10;
+import 'package:auto_route/auto_route.dart' as _i10;
+import 'package:flutter/material.dart' as _i11;
 
 import '../../views/pages/account_settings/account_settings.dart' as _i5;
+import '../../views/pages/account_settings/spending_limit.dart' as _i9;
 import '../../views/pages/account_settings/update_basic_info.dart' as _i8;
 import '../../views/pages/dashboard.dart' as _i2;
 import '../../views/pages/notifications.dart' as _i4;
@@ -22,71 +23,77 @@ import '../../views/pages/transactions.dart' as _i3;
 import '../../views/pages/transactions/add_transaction.dart' as _i7;
 import '../../views/widgets/navigation/bottom_navbar.dart' as _i1;
 
-class AppRouter extends _i9.RootStackRouter {
-  AppRouter([_i10.GlobalKey<_i10.NavigatorState>? navigatorKey])
+class AppRouter extends _i10.RootStackRouter {
+  AppRouter([_i11.GlobalKey<_i11.NavigatorState>? navigatorKey])
       : super(navigatorKey);
 
   @override
-  final Map<String, _i9.PageFactory> pagesMap = {
+  final Map<String, _i10.PageFactory> pagesMap = {
     BottomNavBar.name: (routeData) {
-      return _i9.MaterialPageX<dynamic>(
+      return _i10.MaterialPageX<dynamic>(
           routeData: routeData, child: const _i1.BottomNavBar());
     },
     DashboardRouter.name: (routeData) {
-      return _i9.MaterialPageX<dynamic>(
+      return _i10.MaterialPageX<dynamic>(
           routeData: routeData, child: const _i2.Dashboard());
     },
     TransactionRouter.name: (routeData) {
-      return _i9.MaterialPageX<dynamic>(
+      return _i10.MaterialPageX<dynamic>(
           routeData: routeData, child: const _i3.TransactionsPage());
     },
     NotificationsRouter.name: (routeData) {
-      return _i9.MaterialPageX<dynamic>(
+      return _i10.MaterialPageX<dynamic>(
           routeData: routeData, child: const _i4.NotificationsPage());
     },
     SettingsRouter.name: (routeData) {
-      return _i9.MaterialPageX<dynamic>(
+      return _i10.MaterialPageX<dynamic>(
           routeData: routeData, child: const _i5.AccountSettings());
     },
     SampleCrud.name: (routeData) {
-      return _i9.MaterialPageX<dynamic>(
+      return _i10.MaterialPageX<dynamic>(
           routeData: routeData, child: const _i6.SampleCrud());
     },
     AddTransactionRouter.name: (routeData) {
-      return _i9.MaterialPageX<dynamic>(
+      return _i10.MaterialPageX<dynamic>(
           routeData: routeData, child: const _i7.AddTransaction());
     },
     UpdateBasicInfoRouter.name: (routeData) {
-      return _i9.MaterialPageX<dynamic>(
+      return _i10.MaterialPageX<dynamic>(
           routeData: routeData, child: const _i8.UpdateBasicInfo());
+    },
+    SpendingLimitRouter.name: (routeData) {
+      return _i10.MaterialPageX<dynamic>(
+          routeData: routeData, child: const _i9.SpendingLimit());
     }
   };
 
   @override
-  List<_i9.RouteConfig> get routes => [
-        _i9.RouteConfig(BottomNavBar.name, path: '/', children: [
-          _i9.RouteConfig(DashboardRouter.name,
+  List<_i10.RouteConfig> get routes => [
+        _i10.RouteConfig(BottomNavBar.name, path: '/', children: [
+          _i10.RouteConfig(DashboardRouter.name,
               path: 'dashboard', parent: BottomNavBar.name),
-          _i9.RouteConfig(TransactionRouter.name,
+          _i10.RouteConfig(TransactionRouter.name,
               path: 'transactions', parent: BottomNavBar.name),
-          _i9.RouteConfig(NotificationsRouter.name,
+          _i10.RouteConfig(NotificationsRouter.name,
               path: 'notifications', parent: BottomNavBar.name),
-          _i9.RouteConfig(SettingsRouter.name,
+          _i10.RouteConfig(SettingsRouter.name,
               path: 'account_settings', parent: BottomNavBar.name),
-          _i9.RouteConfig(SampleCrud.name,
+          _i10.RouteConfig(SampleCrud.name,
               path: 'sample_crud', parent: BottomNavBar.name),
-          _i9.RouteConfig(AddTransactionRouter.name,
+          _i10.RouteConfig(AddTransactionRouter.name,
               path: 'add_transaction', parent: BottomNavBar.name),
-          _i9.RouteConfig(UpdateBasicInfoRouter.name,
-              path: 'update_basic_info', parent: BottomNavBar.name)
+          _i10.RouteConfig(UpdateBasicInfoRouter.name,
+              path: 'update_basic_info', parent: BottomNavBar.name),
+          _i10.RouteConfig(SpendingLimitRouter.name,
+              path: 'spending_limit', parent: BottomNavBar.name)
         ])
       ];
 }
 
 /// generated route for
 /// [_i1.BottomNavBar]
-class BottomNavBar extends _i9.PageRouteInfo<void> {
-  const BottomNavBar({List<_i9.PageRouteInfo>? children})
+class BottomNavBar extends _i10.PageRouteInfo<void> {
+  const BottomNavBar({List<_i10.PageRouteInfo>? children})
       : super(BottomNavBar.name, path: '/', initialChildren: children);
 
   static const String name = 'BottomNavBar';
@@ -94,7 +101,7 @@ class BottomNavBar extends _i9.PageRouteInfo<void> {
 
 /// generated route for
 /// [_i2.Dashboard]
-class DashboardRouter extends _i9.PageRouteInfo<void> {
+class DashboardRouter extends _i10.PageRouteInfo<void> {
   const DashboardRouter() : super(DashboardRouter.name, path: 'dashboard');
 
   static const String name = 'DashboardRouter';
@@ -102,7 +109,7 @@ class DashboardRouter extends _i9.PageRouteInfo<void> {
 
 /// generated route for
 /// [_i3.TransactionsPage]
-class TransactionRouter extends _i9.PageRouteInfo<void> {
+class TransactionRouter extends _i10.PageRouteInfo<void> {
   const TransactionRouter()
       : super(TransactionRouter.name, path: 'transactions');
 
@@ -111,7 +118,7 @@ class TransactionRouter extends _i9.PageRouteInfo<void> {
 
 /// generated route for
 /// [_i4.NotificationsPage]
-class NotificationsRouter extends _i9.PageRouteInfo<void> {
+class NotificationsRouter extends _i10.PageRouteInfo<void> {
   const NotificationsRouter()
       : super(NotificationsRouter.name, path: 'notifications');
 
@@ -120,7 +127,7 @@ class NotificationsRouter extends _i9.PageRouteInfo<void> {
 
 /// generated route for
 /// [_i5.AccountSettings]
-class SettingsRouter extends _i9.PageRouteInfo<void> {
+class SettingsRouter extends _i10.PageRouteInfo<void> {
   const SettingsRouter() : super(SettingsRouter.name, path: 'account_settings');
 
   static const String name = 'SettingsRouter';
@@ -128,7 +135,7 @@ class SettingsRouter extends _i9.PageRouteInfo<void> {
 
 /// generated route for
 /// [_i6.SampleCrud]
-class SampleCrud extends _i9.PageRouteInfo<void> {
+class SampleCrud extends _i10.PageRouteInfo<void> {
   const SampleCrud() : super(SampleCrud.name, path: 'sample_crud');
 
   static const String name = 'SampleCrud';
@@ -136,7 +143,7 @@ class SampleCrud extends _i9.PageRouteInfo<void> {
 
 /// generated route for
 /// [_i7.AddTransaction]
-class AddTransactionRouter extends _i9.PageRouteInfo<void> {
+class AddTransactionRouter extends _i10.PageRouteInfo<void> {
   const AddTransactionRouter()
       : super(AddTransactionRouter.name, path: 'add_transaction');
 
@@ -145,9 +152,18 @@ class AddTransactionRouter extends _i9.PageRouteInfo<void> {
 
 /// generated route for
 /// [_i8.UpdateBasicInfo]
-class UpdateBasicInfoRouter extends _i9.PageRouteInfo<void> {
+class UpdateBasicInfoRouter extends _i10.PageRouteInfo<void> {
   const UpdateBasicInfoRouter()
       : super(UpdateBasicInfoRouter.name, path: 'update_basic_info');
 
   static const String name = 'UpdateBasicInfoRouter';
+}
+
+/// generated route for
+/// [_i9.SpendingLimit]
+class SpendingLimitRouter extends _i10.PageRouteInfo<void> {
+  const SpendingLimitRouter()
+      : super(SpendingLimitRouter.name, path: 'spending_limit');
+
+  static const String name = 'SpendingLimitRouter';
 }

--- a/lib/views/pages/account_settings/account_settings.dart
+++ b/lib/views/pages/account_settings/account_settings.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:sun_flutter_capstone/views/pages/account_settings/spending_limit.dart';
 import 'package:sun_flutter_capstone/views/widgets/template.dart';
 import 'package:sun_flutter_capstone/views/widgets/cards/elevated_card.dart';
 import 'package:sun_flutter_capstone/views/widgets/rounded_background.dart';
@@ -84,16 +85,7 @@ class AccountSettings extends HookConsumerWidget {
                         ],
                       ),
                       Spacer(),
-                      IconButton(
-                        icon: const Icon(Icons.edit),
-                        onPressed: () {
-                          print('clicked');
-                        },
-                        color: AppColor.lightGray,
-                        iconSize: 15.0,
-                        alignment: Alignment.centerRight,
-                        padding: EdgeInsets.all(0.0),
-                      ),
+                      SpendingLimit(),
                     ],
                   ),
                 ),

--- a/lib/views/pages/account_settings/spending_limit.dart
+++ b/lib/views/pages/account_settings/spending_limit.dart
@@ -12,8 +12,7 @@ class SpendingLimit extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final formKey = GlobalKey<FormState>();
-    final TextEditingController amountController = 
-    TextEditingController(text: '0.0');
+    final TextEditingController amountController = TextEditingController();
     String currency = 'PHP';
 
     return IconButton(
@@ -46,12 +45,13 @@ class SpendingLimit extends StatelessWidget {
                   child: SingleChildScrollView(
                     padding: EdgeInsets.only(bottom: 40),
                     child: Column(
-                      mainAxisSize: MainAxisSize.min,
                       crossAxisAlignment: CrossAxisAlignment.end,
                       children: [
                         InputGroup(
                           label: 'Update spending limit this month',
                           input: InputField(
+                            hintText: '$currency 0.0',
+                            inputType: TextInputType.number,
                             inputController: amountController,
                           ),
                         ),
@@ -59,11 +59,12 @@ class SpendingLimit extends StatelessWidget {
                         OutlinedButtonText(
                           text: 'Save',
                           onPressed: () {
+                            Navigator.of(context).pop();
                             showDialog(
                               context: context,
                               builder: (BuildContext context) => AlertDialog(
-                                content:
-                                    Text('Values: $currency ${amountController.text}'),
+                                content: Text(
+                                    'Values: $currency ${amountController.text}'),
                               ),
                             );
                           },

--- a/lib/views/pages/account_settings/spending_limit.dart
+++ b/lib/views/pages/account_settings/spending_limit.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:sun_flutter_capstone/consts/global_style.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:sun_flutter_capstone/views/widgets/input/input_field.dart';
+import 'package:sun_flutter_capstone/views/widgets/input/input_group.dart';
+import 'package:sun_flutter_capstone/views/widgets/template.dart';
+import 'package:sun_flutter_capstone/views/widgets/buttons/outline_button_text.dart';
+
+class SpendingLimit extends StatelessWidget {
+  const SpendingLimit({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final formKey = GlobalKey<FormState>();
+    final TextEditingController amountController = 
+    TextEditingController(text: '0.0');
+    String currency = 'PHP';
+
+    return IconButton(
+      icon: const Icon(Icons.edit),
+      color: AppColor.lightGray,
+      iconSize: 15.0,
+      alignment: Alignment.centerRight,
+      padding: EdgeInsets.all(5.0),
+      onPressed: () {
+        showModalBottomSheet<void>(
+          elevation: 5,
+          isScrollControlled: true,
+          context: context,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.vertical(
+              top: Radius.circular(30.0),
+            ),
+          ),
+          builder: (BuildContext context) {
+            return Container(
+              padding: EdgeInsets.only(
+                // this will prevent the soft keyboard from covering the text fields
+                bottom: MediaQuery.of(context).viewInsets.bottom,
+              ),
+              margin: const EdgeInsets.only(top: 50),
+              child: Container(
+                padding: const EdgeInsets.symmetric(horizontal: 30),
+                child: Form(
+                  key: formKey,
+                  child: SingleChildScrollView(
+                    padding: EdgeInsets.only(bottom: 40),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.end,
+                      children: [
+                        InputGroup(
+                          label: 'Update spending limit this month',
+                          input: InputField(
+                            inputController: amountController,
+                          ),
+                        ),
+                        SizedBox(height: 15),
+                        OutlinedButtonText(
+                          text: 'Save',
+                          onPressed: () {
+                            showDialog(
+                              context: context,
+                              builder: (BuildContext context) => AlertDialog(
+                                content:
+                                    Text('Values: $currency ${amountController.text}'),
+                              ),
+                            );
+                          },
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+}

--- a/lib/views/widgets/navigation/bottom_navbar.dart
+++ b/lib/views/widgets/navigation/bottom_navbar.dart
@@ -23,6 +23,7 @@ class BottomNavBar extends HookConsumerWidget {
         SampleCrud(),
         AddTransactionRouter(),
         UpdateBasicInfoRouter(),
+        SpendingLimitRouter(),
       ],
       resizeToAvoidBottomInset: false,
       floatingActionButton:


### PR DESCRIPTION
## Related Links:
- [Notion link](https://www.notion.so/Account-Implement-UI-for-Spending-Limit-setting-644e7b9133fc460faf63d79221dbbfd2)

## Definition of Done
- [ ] Implement UI spending limit
- [ ] Use reusable widget text and button
- [ ] Implement same as figma


## Notes:
- N/A


## Screenshots
![image](https://user-images.githubusercontent.com/89514595/165448958-aa9bff6f-ee9a-4b53-9af5-f9f3ac29469f.png)


## Test View  Points
- [ ] Modal show when click edit icon
