### PR TITLE
[Dashboard] Implement UI for Recent Transactions section

### DIFF
--- a/lib/views/pages/dashboard.dart
+++ b/lib/views/pages/dashboard.dart
@@ -2,10 +2,14 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:sun_flutter_capstone/consts/global_style.dart';
 import 'package:sun_flutter_capstone/controllers/account_controller.dart';
+import 'package:sun_flutter_capstone/consts/routes.dart';
 import 'package:sun_flutter_capstone/state/spending_provider.dart';
+import 'package:sun_flutter_capstone/utils/routing.dart';
+import 'package:sun_flutter_capstone/views/pages/transaction_summary.dart';
 import 'package:sun_flutter_capstone/views/widgets/progress_bar.dart';
 import 'package:sun_flutter_capstone/views/widgets/template.dart';
-import 'package:sun_flutter_capstone/views/pages/transaction_summary.dart';
+import 'package:sun_flutter_capstone/views/widgets/cards/transaction_card.dart';
+
 
 class Dashboard extends StatefulHookConsumerWidget {
   const Dashboard({
@@ -18,20 +22,20 @@ class Dashboard extends StatefulHookConsumerWidget {
   final double totalIncome = 50000;
   final double totalExpenses = 30000;
 
-  final List<Map> data = const [
+  final List<Map<String, dynamic>> data = const [
     {
       'type': 'income',
       'description': 'Salary',
       'amount': 50000.0,
       'icon': Icons.attach_money_outlined,
-      'date': '2022-04-25T11:00:00.000Z'
+      'date': '2022-04-25T11:00:00.000Z',
     },
     {
       'type': 'expenses',
       'description': 'Gas bill',
       'amount': 3000.0,
       'icon': Icons.drive_eta_outlined,
-      'date': '2022-04-23T11:00:00.000Z'
+      'date': '2022-04-23T11:00:00.000Z',
     },
   ];
 
@@ -41,8 +45,9 @@ class Dashboard extends StatefulHookConsumerWidget {
       return 'Good morning,';
     } else if (hour < 17) {
       return 'Good afternoon,';
-    } else
+    } else {
       return 'Good evening,';
+    }
   }
 
   @override
@@ -71,52 +76,131 @@ class _DashboardState extends ConsumerState<Dashboard> {
         ],
       ),
       isTitleCenter: false,
-      content: SingleChildScrollView(
+      content: Container(
+        alignment: Alignment.center,
         child: Container(
-          alignment: Alignment.center,
-          child: Container(
-            margin: EdgeInsets.symmetric(horizontal: 10.0),
-            child: Column(
-              children: [
-                TransactionSummary(
-                  totalBalance: widget.totalIncome - widget.totalExpenses,
-                  totalIncome: widget.totalIncome,
-                  totalExpenses: widget.totalExpenses,
-                  currency: widget.currency,
+          margin: EdgeInsets.symmetric(horizontal: 10.0),
+          child: Column(
+            children: [
+              TransactionSummary(
+                totalBalance: widget.totalIncome - widget.totalExpenses,
+                totalIncome: widget.totalIncome,
+                totalExpenses: widget.totalExpenses,
+                currency: widget.currency,
+              ),
+              Container(
+                margin:
+                    EdgeInsets.only(top: 35, left: 20, right: 20, bottom: 10),
+                child: ProgressBar(
+                  progress: spendingAmount,
+                  label: "You have spent",
                 ),
-                Container(
-                  margin:
-                      EdgeInsets.only(top: 35, left: 20, right: 20, bottom: 10),
-                  child: ProgressBar(
-                    progress: spendingAmount,
-                    label: "You have spent",
-                  ),
-                ),
-                // * The following row can be removed this is just for testing the progress bar
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    Flexible(
-                      child: ElevatedButton(
-                        onPressed: () {
-                          setSpendingAmount(ref, spendingAmount - 0.1);
-                        },
-                        child: const Text('-'),
-                      ),
+              ),
+              // * The following row can be removed this is just for testing the progress bar
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Flexible(
+                    child: ElevatedButton(
+                      onPressed: () {
+                        setSpendingAmount(ref, spendingAmount - 0.1);
+                      },
+                      child: const Text('-'),
                     ),
-                    const SizedBox(width: 30),
-                    Flexible(
-                      child: ElevatedButton(
-                        onPressed: () {
-                          setSpendingAmount(ref, spendingAmount + 0.1);
-                        },
-                        child: const Text('+'),
-                      ),
-                    )
+                  ),
+                  const SizedBox(width: 30),
+                  Flexible(
+                    child: ElevatedButton(
+                      onPressed: () {
+                        setSpendingAmount(ref, spendingAmount + 0.1);
+                      },
+                      child: const Text('+'),
+                    ),
+                  )
+                ],
+              ),
+              // Recent transactions
+              Container(
+                margin:
+                    EdgeInsets.only(top: 20, bottom: 19, left: 10, right: 10),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Text(
+                      'Recent Transactions',
+                      style:
+                          TextStyle(fontWeight: FontWeight.w600, fontSize: 18),
+                    ),
+                    TextButton(
+                      style: TextButton.styleFrom(
+                          primary: Colors.black.withOpacity(0.5),
+                          textStyle: TextStyle(fontSize: 14)),
+                      onPressed: () => redirectTo(context, Routes.transactions),
+                      child: Text('See all'),
+                    ),
                   ],
                 ),
-              ],
-            ),
+              ),
+              Expanded(
+                child: SingleChildScrollView(
+                  child: Container(
+                    margin: EdgeInsets.symmetric(horizontal: 10),
+                    child: Column(
+                      children: [
+                        Container(
+                          margin: EdgeInsets.only(bottom: 16),
+                          child: TransactionCard(
+                            icon: Icon(widget.data[0]['icon'],
+                                color: Colors.black.withOpacity(0.5)),
+                            type: widget.data[0]['type'],
+                            currency: 'PHP',
+                            amount: widget.data[0]['amount'],
+                            description: widget.data[0]['description'],
+                            dateTime: DateTime.parse(widget.data[0]['date']),
+                          ),
+                        ),
+                        Container(
+                          margin: EdgeInsets.only(bottom: 16),
+                          child: TransactionCard(
+                            icon: Icon(widget.data[1]['icon'],
+                                color: Colors.black.withOpacity(0.5)),
+                            type: widget.data[1]['type'],
+                            currency: 'PHP',
+                            amount: widget.data[1]['amount'],
+                            description: widget.data[1]['description'],
+                            dateTime: DateTime.parse(widget.data[1]['date']),
+                          ),
+                        ),
+                        Container(
+                          margin: EdgeInsets.only(bottom: 16),
+                          child: TransactionCard(
+                            icon: Icon(widget.data[1]['icon'],
+                                color: Colors.black.withOpacity(0.5)),
+                            type: widget.data[1]['type'],
+                            currency: 'PHP',
+                            amount: widget.data[1]['amount'],
+                            description: widget.data[1]['description'],
+                            dateTime: DateTime.parse(widget.data[1]['date']),
+                          ),
+                        ),
+                        Container(
+                          margin: EdgeInsets.only(bottom: 16),
+                          child: TransactionCard(
+                            icon: Icon(widget.data[1]['icon'],
+                                color: Colors.black.withOpacity(0.5)),
+                            type: widget.data[1]['type'],
+                            currency: 'PHP',
+                            amount: widget.data[1]['amount'],
+                            description: widget.data[1]['description'],
+                            dateTime: DateTime.parse(widget.data[1]['date']),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              )
+            ],
           ),
         ),
       ),

--- a/lib/views/pages/dashboard.dart
+++ b/lib/views/pages/dashboard.dart
@@ -10,7 +10,6 @@ import 'package:sun_flutter_capstone/views/widgets/progress_bar.dart';
 import 'package:sun_flutter_capstone/views/widgets/template.dart';
 import 'package:sun_flutter_capstone/views/widgets/cards/transaction_card.dart';
 
-
 class Dashboard extends StatefulHookConsumerWidget {
   const Dashboard({
     Key? key,
@@ -58,6 +57,31 @@ class Dashboard extends StatefulHookConsumerWidget {
       'icon': Icons.drive_eta_outlined,
       'date': '2022-04-23T11:00:00.000Z',
     },
+    {
+      'type': 'expenses',
+      'description': 'Gas bill',
+      'amount': 3000.0,
+      'icon': Icons.drive_eta_outlined,
+      'date': '2022-04-23T11:00:00.000Z',
+    },{
+      'type': 'expenses',
+      'description': 'Gas bill',
+      'amount': 3000.0,
+      'icon': Icons.drive_eta_outlined,
+      'date': '2022-04-23T11:00:00.000Z',
+    },{
+      'type': 'expenses',
+      'description': 'Gas bill',
+      'amount': 3000.0,
+      'icon': Icons.drive_eta_outlined,
+      'date': '2022-04-23T11:00:00.000Z',
+    },{
+      'type': 'expenses',
+      'description': 'Gas bill',
+      'amount': 3000.0,
+      'icon': Icons.drive_eta_outlined,
+      'date': '2022-04-23T11:00:00.000Z',
+    },
   ];
 
   String _greeting() {
@@ -76,24 +100,22 @@ class Dashboard extends StatefulHookConsumerWidget {
 }
 
 class _DashboardState extends ConsumerState<Dashboard> {
-  get transactions  {
+  get transactions {
     var transactionWidgets = <Widget>[];
-    
+
     for (var transactionData in widget.data) {
-      transactionWidgets.add(
-        Container(
-          margin: EdgeInsets.only(bottom: 16),
-          child: TransactionCard(
-            icon: Icon(transactionData['icon'],
-                color: Colors.black.withOpacity(0.5)),
-            type: transactionData['type'],
-            currency: 'PHP',
-            amount: transactionData['amount'],
-            description: transactionData['description'],
-            dateTime: DateTime.parse(transactionData['date']),
-          ),
-        )
-      );
+      transactionWidgets.add(Container(
+        margin: EdgeInsets.only(bottom: 16),
+        child: TransactionCard(
+          icon: Icon(transactionData['icon'],
+              color: Colors.black.withOpacity(0.5)),
+          type: transactionData['type'],
+          currency: 'PHP',
+          amount: transactionData['amount'],
+          description: transactionData['description'],
+          dateTime: DateTime.parse(transactionData['date']),
+        ),
+      ));
     }
 
     return transactionWidgets;
@@ -114,88 +136,84 @@ class _DashboardState extends ConsumerState<Dashboard> {
             style: TextStyle(color: AppColor.gray, fontSize: 14),
           ),
           Text(
-            signedInAccount?.name ?? '',
+            signedInAccount?.name ?? 'Aubrey',
             style: TextStyle(color: AppColor.secondary, fontSize: 20),
           ),
         ],
       ),
       isTitleCenter: false,
-      content: Container(
-        alignment: Alignment.center,
+      content: SingleChildScrollView(
         child: Container(
-          margin: EdgeInsets.symmetric(horizontal: 10.0),
-          child: Column(
-            children: [
-              TransactionSummary(
-                totalBalance: widget.totalIncome - widget.totalExpenses,
-                totalIncome: widget.totalIncome,
-                totalExpenses: widget.totalExpenses,
-                currency: widget.currency,
-              ),
-              Container(
-                margin:
-                    EdgeInsets.only(top: 35, left: 20, right: 20, bottom: 10),
-                child: ProgressBar(
-                  progress: spendingAmount,
-                  label: "You have spent",
+          alignment: Alignment.center,
+          child: Container(
+            margin: EdgeInsets.symmetric(horizontal: 10.0),
+            child: Column(
+              children: [
+                TransactionSummary(
+                  totalBalance: widget.totalIncome - widget.totalExpenses,
+                  totalIncome: widget.totalIncome,
+                  totalExpenses: widget.totalExpenses,
+                  currency: widget.currency,
                 ),
-              ),
-              // * The following row can be removed this is just for testing the progress bar
-              Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Flexible(
-                    child: ElevatedButton(
-                      onPressed: () {
-                        setSpendingAmount(ref, spendingAmount - 0.1);
-                      },
-                      child: const Text('-'),
-                    ),
+                Container(
+                  margin:
+                      EdgeInsets.only(top: 35, left: 20, right: 20, bottom: 10),
+                  child: ProgressBar(
+                    progress: spendingAmount,
+                    label: "You have spent",
                   ),
-                  const SizedBox(width: 30),
-                  Flexible(
-                    child: ElevatedButton(
-                      onPressed: () {
-                        setSpendingAmount(ref, spendingAmount + 0.1);
-                      },
-                      child: const Text('+'),
-                    ),
-                  )
-                ],
-              ),
-              // Recent transactions
-              Container(
-                margin:
-                    EdgeInsets.only(top: 20, bottom: 5, left: 10, right: 10),
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                ),
+                // * The following row can be removed this is just for testing the progress bar
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
                   children: [
-                    Text(
-                      'Recent Transactions',
-                      style:
-                          TextStyle(fontWeight: FontWeight.w600, fontSize: 18),
+                    Flexible(
+                      child: ElevatedButton(
+                        onPressed: () {
+                          setSpendingAmount(ref, spendingAmount - 0.1);
+                        },
+                        child: const Text('-'),
+                      ),
                     ),
-                    TextButton(
-                      style: TextButton.styleFrom(
-                          primary: Colors.black.withOpacity(0.5),
-                          textStyle: TextStyle(fontSize: 14)),
-                      onPressed: () => redirectTo(context, Routes.transactions),
-                      child: Text('See all'),
-                    ),
+                    const SizedBox(width: 30),
+                    Flexible(
+                      child: ElevatedButton(
+                        onPressed: () {
+                          setSpendingAmount(ref, spendingAmount + 0.1);
+                        },
+                        child: const Text('+'),
+                      ),
+                    )
                   ],
                 ),
-              ),
-              Expanded(
-                child: SingleChildScrollView(
-                  child: Container(
-                    margin: EdgeInsets.symmetric(horizontal: 10),
-                    child: Column(
-                      children: transactions
-                    ),
+                // Recent transactions
+                Container(
+                  margin:
+                      EdgeInsets.only(top: 20, bottom: 5, left: 10, right: 10),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Text(
+                        'Recent Transactions',
+                        style:
+                            TextStyle(fontWeight: FontWeight.w600, fontSize: 18),
+                      ),
+                      TextButton(
+                        style: TextButton.styleFrom(
+                            primary: Colors.black.withOpacity(0.5),
+                            textStyle: TextStyle(fontSize: 14)),
+                        onPressed: () => redirectTo(context, Routes.transactions),
+                        child: Text('See all'),
+                      ),
+                    ],
                   ),
                 ),
-              )
-            ],
+                Container(
+                  margin: EdgeInsets.symmetric(horizontal: 10),
+                  child: Column(children: transactions),
+                )
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/views/pages/dashboard.dart
+++ b/lib/views/pages/dashboard.dart
@@ -37,6 +37,27 @@ class Dashboard extends StatefulHookConsumerWidget {
       'icon': Icons.drive_eta_outlined,
       'date': '2022-04-23T11:00:00.000Z',
     },
+    {
+      'type': 'expenses',
+      'description': 'Gas bill',
+      'amount': 3000.0,
+      'icon': Icons.drive_eta_outlined,
+      'date': '2022-04-23T11:00:00.000Z',
+    },
+    {
+      'type': 'expenses',
+      'description': 'Gas bill',
+      'amount': 3000.0,
+      'icon': Icons.drive_eta_outlined,
+      'date': '2022-04-23T11:00:00.000Z',
+    },
+    {
+      'type': 'expenses',
+      'description': 'Gas bill',
+      'amount': 3000.0,
+      'icon': Icons.drive_eta_outlined,
+      'date': '2022-04-23T11:00:00.000Z',
+    },
   ];
 
   String _greeting() {
@@ -55,6 +76,29 @@ class Dashboard extends StatefulHookConsumerWidget {
 }
 
 class _DashboardState extends ConsumerState<Dashboard> {
+  get transactions  {
+    var transactionWidgets = <Widget>[];
+    
+    for (var transactionData in widget.data) {
+      transactionWidgets.add(
+        Container(
+          margin: EdgeInsets.only(bottom: 16),
+          child: TransactionCard(
+            icon: Icon(transactionData['icon'],
+                color: Colors.black.withOpacity(0.5)),
+            type: transactionData['type'],
+            currency: 'PHP',
+            amount: transactionData['amount'],
+            description: transactionData['description'],
+            dateTime: DateTime.parse(transactionData['date']),
+          ),
+        )
+      );
+    }
+
+    return transactionWidgets;
+  }
+
   @override
   Widget build(BuildContext context) {
     final signedInAccount = ref.watch(accountProvider);
@@ -122,7 +166,7 @@ class _DashboardState extends ConsumerState<Dashboard> {
               // Recent transactions
               Container(
                 margin:
-                    EdgeInsets.only(top: 20, bottom: 19, left: 10, right: 10),
+                    EdgeInsets.only(top: 20, bottom: 5, left: 10, right: 10),
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
@@ -146,56 +190,7 @@ class _DashboardState extends ConsumerState<Dashboard> {
                   child: Container(
                     margin: EdgeInsets.symmetric(horizontal: 10),
                     child: Column(
-                      children: [
-                        Container(
-                          margin: EdgeInsets.only(bottom: 16),
-                          child: TransactionCard(
-                            icon: Icon(widget.data[0]['icon'],
-                                color: Colors.black.withOpacity(0.5)),
-                            type: widget.data[0]['type'],
-                            currency: 'PHP',
-                            amount: widget.data[0]['amount'],
-                            description: widget.data[0]['description'],
-                            dateTime: DateTime.parse(widget.data[0]['date']),
-                          ),
-                        ),
-                        Container(
-                          margin: EdgeInsets.only(bottom: 16),
-                          child: TransactionCard(
-                            icon: Icon(widget.data[1]['icon'],
-                                color: Colors.black.withOpacity(0.5)),
-                            type: widget.data[1]['type'],
-                            currency: 'PHP',
-                            amount: widget.data[1]['amount'],
-                            description: widget.data[1]['description'],
-                            dateTime: DateTime.parse(widget.data[1]['date']),
-                          ),
-                        ),
-                        Container(
-                          margin: EdgeInsets.only(bottom: 16),
-                          child: TransactionCard(
-                            icon: Icon(widget.data[1]['icon'],
-                                color: Colors.black.withOpacity(0.5)),
-                            type: widget.data[1]['type'],
-                            currency: 'PHP',
-                            amount: widget.data[1]['amount'],
-                            description: widget.data[1]['description'],
-                            dateTime: DateTime.parse(widget.data[1]['date']),
-                          ),
-                        ),
-                        Container(
-                          margin: EdgeInsets.only(bottom: 16),
-                          child: TransactionCard(
-                            icon: Icon(widget.data[1]['icon'],
-                                color: Colors.black.withOpacity(0.5)),
-                            type: widget.data[1]['type'],
-                            currency: 'PHP',
-                            amount: widget.data[1]['amount'],
-                            description: widget.data[1]['description'],
-                            dateTime: DateTime.parse(widget.data[1]['date']),
-                          ),
-                        ),
-                      ],
+                      children: transactions
                     ),
                   ),
                 ),

--- a/lib/views/widgets/template.dart
+++ b/lib/views/widgets/template.dart
@@ -44,13 +44,13 @@ class Template extends StatelessWidget {
               ),
             ),
             Positioned(
-              top: 0.0,
-              left: 0.0,
+              top: 0,
+              left: 0,
               right: 0.0,
               child: Padding(
                 padding: const EdgeInsets.only(top: 10),
                 child: AppBar(
-                  toolbarHeight: 80,
+                  toolbarHeight: 60,
                   title: appbarTitle,
                   actions: appbarActions,
                   centerTitle: isTitleCenter,


### PR DESCRIPTION
## Related Links:
- [Issue link](https://www.notion.so/Dashboard-Implement-UI-for-Recent-Transactions-section-b3548ec19cb44c948471a9aeadd6bc28)

## Definition of Done
- [ ] Display sample transaction card list on Dashboard screen
- [ ]  **See all** should redirect to Transactions history screen

## Notes:
- N/A


## Screenshots
<img width="494" alt="image" src="https://user-images.githubusercontent.com/21002044/165497494-33d3d966-3b43-47e5-a805-e600709432c6.png">

## Test View  Points
- [ ] N/A
