### PR TITLE
[Account] Implement Spending Limit setting

### DIFF
--- a/lib/controllers/spending_limit_controller.dart
+++ b/lib/controllers/spending_limit_controller.dart
@@ -15,14 +15,16 @@ class SpendingLimitController {
   }
 
   Future<int?> upsert(double limitAmount) async {
-    var now = DateTime.now();
+    DateTime now = DateTime.now();
+    DateTime firstDayOfMonth = DateTime(now.year, now.month, 1);
+    DateTime lastDayOfMonth = DateTime(now.year, now.month + 1, 0);
     Spending_limit? spendingLimit = await getCurrentSpendingLimit(now);
     
     final result = await Spending_limit(
       id: spendingLimit?.id,
       amount: limitAmount,
-      start_date: DateTime.now(),
-      end_date: DateTime.now().add(Duration(days: 30)),
+      start_date: firstDayOfMonth,
+      end_date: lastDayOfMonth,
       createdAt: DateTime.now(),
       updatedAt: DateTime.now(),
     ).upsert();
@@ -31,15 +33,15 @@ class SpendingLimitController {
 }
 
 final spendingLimitProvider =
-    StateNotifierProvider<SpendingLimitNotifier, double?>(
+    StateNotifierProvider<SpendingLimitNotifier, double>(
         (_) => SpendingLimitNotifier(0.0));
 
-class SpendingLimitNotifier extends StateNotifier<double?> {
-  SpendingLimitNotifier(double? state) : super(state);
+class SpendingLimitNotifier extends StateNotifier<double> {
+  SpendingLimitNotifier(double state) : super(state);
 
   Future<void> getSpendingLimit() async {
     Spending_limit? spendingLimit =
         await SpendingLimitController().getCurrentSpendingLimit(DateTime.now());
-    state = spendingLimit?.amount;
+    state = (spendingLimit != null ? spendingLimit.amount : 0.0)!;
   }
 }

--- a/lib/controllers/spending_limit_controller.dart
+++ b/lib/controllers/spending_limit_controller.dart
@@ -1,3 +1,4 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:sun_flutter_capstone/models/model.dart';
 
 class SpendingLimitController {
@@ -26,5 +27,19 @@ class SpendingLimitController {
       updatedAt: DateTime.now(),
     ).upsert();
     return result;
+  }
+}
+
+final spendingLimitProvider =
+    StateNotifierProvider<SpendingLimitNotifier, double?>(
+        (_) => SpendingLimitNotifier(0.0));
+
+class SpendingLimitNotifier extends StateNotifier<double?> {
+  SpendingLimitNotifier(double? state) : super(state);
+
+  Future<void> getSpendingLimit() async {
+    Spending_limit? spendingLimit =
+        await SpendingLimitController().getCurrentSpendingLimit(DateTime.now());
+    state = spendingLimit?.amount;
   }
 }

--- a/lib/controllers/spending_limit_controller.dart
+++ b/lib/controllers/spending_limit_controller.dart
@@ -1,26 +1,25 @@
-import 'package:intl/intl.dart';
 import 'package:sun_flutter_capstone/models/model.dart';
 
 class SpendingLimitController {
-  Future<List<Spending_limit>> index(
-      DateTime? startDate, DateTime? endDate) async {
-    if (startDate != null && endDate != null) {
-      return await Spending_limit()
-          .select()
-          .start_date
-          .lessThanOrEquals(startDate)
-          .and
-          .end_date
-          .greaterThanOrEquals(endDate)
-          .toList();
-    }
-    return await Spending_limit().select().toList();
+  Future<Spending_limit?> getCurrentSpendingLimit(
+    DateTime dateNow) async {
+    return await Spending_limit()
+      .select()
+      .start_date
+      .lessThanOrEquals(dateNow)
+      .and
+      .end_date
+      .greaterThanOrEquals(dateNow)
+      .toSingle();
   }
 
-  Future<int?> upsert(Spending_limit spending_limit) async {
+  Future<int?> upsert(double limitAmount) async {
+    var now = DateTime.now();
+    Spending_limit? spendingLimit = await getCurrentSpendingLimit(now);
+    
     final result = await Spending_limit(
-      id: spending_limit.id,
-      amount: spending_limit.amount,
+      id: spendingLimit?.id,
+      amount: limitAmount,
       start_date: DateTime.now(),
       end_date: DateTime.now().add(Duration(days: 30)),
       createdAt: DateTime.now(),

--- a/lib/controllers/spending_limit_controller.dart
+++ b/lib/controllers/spending_limit_controller.dart
@@ -1,0 +1,16 @@
+import 'package:sun_flutter_capstone/models/model.dart';
+
+class SpendingLimitController {
+
+  Future<int?> upsert(Spending_limit spending_limit) async {
+    final result = await Spending_limit(
+      id: spending_limit.id,
+      amount: spending_limit.amount,
+      start_date: DateTime.now(),
+      end_date: DateTime.now(),
+      createdAt: DateTime.now(),
+      updatedAt: DateTime.now(),
+    ).upsert();
+    return result;
+  }
+}

--- a/lib/controllers/spending_limit_controller.dart
+++ b/lib/controllers/spending_limit_controller.dart
@@ -1,13 +1,25 @@
+import 'package:intl/intl.dart';
 import 'package:sun_flutter_capstone/models/model.dart';
 
 class SpendingLimitController {
+  Future<List<Spending_limit>> index(DateTime? startDate, DateTime? endDate) async {
+    if (startDate != null && endDate != null) {
+      return await Spending_limit()
+          .select()
+          .amount
+          .between(DateTime.parse(DateFormat('yyyy-MM-dd').format(startDate)),
+              DateTime.parse(DateFormat('yyyy-MM-dd').format(endDate)))
+          .toList();
+    }
+    return await Spending_limit().select().toList();
+  }
 
   Future<int?> upsert(Spending_limit spending_limit) async {
     final result = await Spending_limit(
       id: spending_limit.id,
       amount: spending_limit.amount,
       start_date: DateTime.now(),
-      end_date: DateTime.now(),
+      end_date: DateTime.now().add(Duration(days: 30)),
       createdAt: DateTime.now(),
       updatedAt: DateTime.now(),
     ).upsert();

--- a/lib/controllers/spending_limit_controller.dart
+++ b/lib/controllers/spending_limit_controller.dart
@@ -2,13 +2,16 @@ import 'package:intl/intl.dart';
 import 'package:sun_flutter_capstone/models/model.dart';
 
 class SpendingLimitController {
-  Future<List<Spending_limit>> index(DateTime? startDate, DateTime? endDate) async {
+  Future<List<Spending_limit>> index(
+      DateTime? startDate, DateTime? endDate) async {
     if (startDate != null && endDate != null) {
       return await Spending_limit()
           .select()
-          .amount
-          .between(DateTime.parse(DateFormat('yyyy-MM-dd').format(startDate)),
-              DateTime.parse(DateFormat('yyyy-MM-dd').format(endDate)))
+          .start_date
+          .lessThanOrEquals(startDate)
+          .and
+          .end_date
+          .greaterThanOrEquals(endDate)
           .toList();
     }
     return await Spending_limit().select().toList();

--- a/lib/utils/routes/router.gr.dart
+++ b/lib/utils/routes/router.gr.dart
@@ -67,8 +67,11 @@ class AppRouter extends _i11.RootStackRouter {
           routeData: routeData, child: const _i9.UpdateBasicInfo());
     },
     SpendingLimitRouter.name: (routeData) {
+      final args = routeData.argsAs<SpendingLimitRouterArgs>(
+          orElse: () => const SpendingLimitRouterArgs());
       return _i11.MaterialPageX<dynamic>(
-          routeData: routeData, child: const _i10.SpendingLimit());
+          routeData: routeData,
+          child: _i10.SpendingLimit(key: args.key, amount: args.amount));
     }
   };
 
@@ -175,9 +178,24 @@ class UpdateBasicInfoRouter extends _i11.PageRouteInfo<void> {
 
 /// generated route for
 /// [_i10.SpendingLimit]
-class SpendingLimitRouter extends _i11.PageRouteInfo<void> {
-  const SpendingLimitRouter()
-      : super(SpendingLimitRouter.name, path: 'spending_limit');
+class SpendingLimitRouter extends _i11.PageRouteInfo<SpendingLimitRouterArgs> {
+  SpendingLimitRouter({_i12.Key? key, String amount = '0.0'})
+      : super(SpendingLimitRouter.name,
+            path: 'spending_limit',
+            args: SpendingLimitRouterArgs(key: key, amount: amount));
 
   static const String name = 'SpendingLimitRouter';
+}
+
+class SpendingLimitRouterArgs {
+  const SpendingLimitRouterArgs({this.key, this.amount = '0.0'});
+
+  final _i12.Key? key;
+
+  final String amount;
+
+  @override
+  String toString() {
+    return 'SpendingLimitRouterArgs{key: $key, amount: $amount}';
+  }
 }

--- a/lib/views/pages/account_settings/account_settings.dart
+++ b/lib/views/pages/account_settings/account_settings.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:sun_flutter_capstone/controllers/account_controller.dart';
+import 'package:sun_flutter_capstone/controllers/spending_limit_controller.dart';
 import 'package:sun_flutter_capstone/views/pages/account_settings/spending_limit.dart';
 import 'package:sun_flutter_capstone/views/widgets/template.dart';
 import 'package:sun_flutter_capstone/views/widgets/cards/elevated_card.dart';
@@ -19,7 +20,30 @@ class AccountSettings extends StatefulHookConsumerWidget {
 }
 
 class _AccountSettingsState extends ConsumerState<AccountSettings> {
-  final double spendingLimit = 18000.0;
+  final String currency = 'PHP';
+  final String spendingLimit = '18,000';
+  final SpendingLimitController spendingLimitController =
+      SpendingLimitController();
+
+  String currentSpendingLimit = '0.0';
+
+  @override
+  void initState() {
+    super.initState();
+    _totalValues();
+  }
+
+  Future<void> _totalValues() async {
+    var now = DateTime.now();
+    var monthAfter = DateTime.now().add(Duration(days: 5));
+
+    List spendlingLimits = await spendingLimitController.index(now, monthAfter);
+    debugPrint(spendlingLimits[0].amount.toString());
+
+    setState(() {
+      currentSpendingLimit = spendlingLimits[0].amount.toString();
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -82,7 +106,7 @@ class _AccountSettingsState extends ConsumerState<AccountSettings> {
                             ),
                           ),
                           Text(
-                            amountFormat.amount(spendingLimit, signedInUser?.currency ?? 'PHP'),
+                            amountFormat.amount(currentSpendingLimit, signedInUser?.currency ?? 'PHP'),
                             style: TextStyle(
                               fontSize: 18,
                               fontWeight: FontWeight.w600,
@@ -92,7 +116,7 @@ class _AccountSettingsState extends ConsumerState<AccountSettings> {
                         ],
                       ),
                     Spacer(),
-                    SpendingLimit(),
+                    SpendingLimit(amount: currentSpendingLimit),
                   ],
                 ),
               ),

--- a/lib/views/pages/account_settings/account_settings.dart
+++ b/lib/views/pages/account_settings/account_settings.dart
@@ -21,7 +21,6 @@ class AccountSettings extends StatefulHookConsumerWidget {
 
 class _AccountSettingsState extends ConsumerState<AccountSettings> {
   final String currency = 'PHP';
-  final String spendingLimit = '18,000';
   final SpendingLimitController spendingLimitController =
       SpendingLimitController();
 
@@ -30,18 +29,14 @@ class _AccountSettingsState extends ConsumerState<AccountSettings> {
   @override
   void initState() {
     super.initState();
-    _totalValues();
+    _getSpendingLimit();
   }
 
-  Future<void> _totalValues() async {
+  Future<void> _getSpendingLimit() async {
     var now = DateTime.now();
-    var monthAfter = DateTime.now().add(Duration(days: 5));
-
-    List spendlingLimits = await spendingLimitController.index(now, monthAfter);
-    debugPrint(spendlingLimits[0].amount.toString());
-
+    final spendingLimit = await spendingLimitController.getCurrentSpendingLimit(now);
     setState(() {
-      currentSpendingLimit = spendlingLimits[0].amount.toString();
+      currentSpendingLimit = spendingLimit != null ? spendingLimit.amount.toString() : '0.0';
     });
   }
 

--- a/lib/views/pages/account_settings/account_settings.dart
+++ b/lib/views/pages/account_settings/account_settings.dart
@@ -24,26 +24,12 @@ class _AccountSettingsState extends ConsumerState<AccountSettings> {
   final SpendingLimitController spendingLimitController =
       SpendingLimitController();
 
-  String currentSpendingLimit = '0.0';
-
-  @override
-  void initState() {
-    super.initState();
-    _getSpendingLimit();
-  }
-
-  Future<void> _getSpendingLimit() async {
-    var now = DateTime.now();
-    final spendingLimit = await spendingLimitController.getCurrentSpendingLimit(now);
-    setState(() {
-      currentSpendingLimit = spendingLimit != null ? spendingLimit.amount.toString() : '0.0';
-    });
-  }
-
   @override
   Widget build(BuildContext context) {
     final signedInUser = ref.watch(accountProvider);
     final amountFormat = AmountFormat();
+    final spendingLimitState = ref.watch(spendingLimitProvider);
+    ref.read(spendingLimitProvider.notifier).getSpendingLimit();
 
     return Template(
       appbarTitle: Text(
@@ -101,7 +87,7 @@ class _AccountSettingsState extends ConsumerState<AccountSettings> {
                             ),
                           ),
                           Text(
-                            amountFormat.amount(currentSpendingLimit, signedInUser?.currency ?? 'PHP'),
+                            amountFormat.amount(spendingLimitState, signedInUser?.currency ?? 'PHP'),
                             style: TextStyle(
                               fontSize: 18,
                               fontWeight: FontWeight.w600,
@@ -111,7 +97,7 @@ class _AccountSettingsState extends ConsumerState<AccountSettings> {
                         ],
                       ),
                     Spacer(),
-                    SpendingLimit(amount: currentSpendingLimit),
+                    SpendingLimit(amount: spendingLimitState.toString()),
                   ],
                 ),
               ),

--- a/lib/views/pages/account_settings/spending_limit.dart
+++ b/lib/views/pages/account_settings/spending_limit.dart
@@ -9,7 +9,9 @@ import 'package:sun_flutter_capstone/views/widgets/template.dart';
 import 'package:sun_flutter_capstone/views/widgets/buttons/outline_button_text.dart';
 
 class SpendingLimit extends StatelessWidget {
-  const SpendingLimit({Key? key}) : super(key: key);
+  final String amount;
+
+  const SpendingLimit({Key? key, this.amount = '0.0'}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -53,7 +55,7 @@ class SpendingLimit extends StatelessWidget {
                         InputGroup(
                           label: 'Update spending limit this month',
                           input: InputField(
-                            hintText: '$currency 0.0',
+                            hintText: '$currency $amount',
                             inputType: TextInputType.number,
                             inputController: amountController,
                           ),

--- a/lib/views/pages/account_settings/spending_limit.dart
+++ b/lib/views/pages/account_settings/spending_limit.dart
@@ -67,7 +67,7 @@ class SpendingLimit extends StatelessWidget {
                               id: null,
                               amount: double.parse(amountController.text),
                               start_date: DateTime.now(),
-                              end_date: DateTime.now(),
+                              end_date: DateTime.now().add(Duration(days: 30)),
                               createdAt: DateTime.now(),
                               updatedAt: DateTime.now(),
                             );

--- a/lib/views/pages/account_settings/spending_limit.dart
+++ b/lib/views/pages/account_settings/spending_limit.dart
@@ -1,11 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:sun_flutter_capstone/consts/global_style.dart';
-import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:sun_flutter_capstone/controllers/spending_limit_controller.dart';
-import 'package:sun_flutter_capstone/models/model.dart';
 import 'package:sun_flutter_capstone/views/widgets/input/input_field.dart';
 import 'package:sun_flutter_capstone/views/widgets/input/input_group.dart';
-import 'package:sun_flutter_capstone/views/widgets/template.dart';
 import 'package:sun_flutter_capstone/views/widgets/buttons/outline_button_text.dart';
 
 class SpendingLimit extends StatelessWidget {
@@ -65,16 +62,8 @@ class SpendingLimit extends StatelessWidget {
                           text: 'Save',
                           onPressed: () async {
                             Navigator.of(context).pop();
-                            Spending_limit spending_limit = Spending_limit(
-                              id: null,
-                              amount: double.parse(amountController.text),
-                              start_date: DateTime.now(),
-                              end_date: DateTime.now().add(Duration(days: 30)),
-                              createdAt: DateTime.now(),
-                              updatedAt: DateTime.now(),
-                            );
                             await spendingLimitController
-                                .upsert(spending_limit);
+                                .upsert(double.parse(amountController.text));
                             showDialog(
                               context: context,
                               builder: (BuildContext context) => AlertDialog(

--- a/lib/views/pages/account_settings/spending_limit.dart
+++ b/lib/views/pages/account_settings/spending_limit.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:sun_flutter_capstone/consts/global_style.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:sun_flutter_capstone/controllers/spending_limit_controller.dart';
+import 'package:sun_flutter_capstone/models/model.dart';
 import 'package:sun_flutter_capstone/views/widgets/input/input_field.dart';
 import 'package:sun_flutter_capstone/views/widgets/input/input_group.dart';
 import 'package:sun_flutter_capstone/views/widgets/template.dart';
@@ -14,6 +16,7 @@ class SpendingLimit extends StatelessWidget {
     final formKey = GlobalKey<FormState>();
     final TextEditingController amountController = TextEditingController();
     String currency = 'PHP';
+    SpendingLimitController spendingLimitController = SpendingLimitController();
 
     return IconButton(
       icon: const Icon(Icons.edit),
@@ -58,8 +61,18 @@ class SpendingLimit extends StatelessWidget {
                         SizedBox(height: 15),
                         OutlinedButtonText(
                           text: 'Save',
-                          onPressed: () {
+                          onPressed: () async {
                             Navigator.of(context).pop();
+                            Spending_limit spending_limit = Spending_limit(
+                              id: null,
+                              amount: double.parse(amountController.text),
+                              start_date: DateTime.now(),
+                              end_date: DateTime.now(),
+                              createdAt: DateTime.now(),
+                              updatedAt: DateTime.now(),
+                            );
+                            await spendingLimitController
+                                .upsert(spending_limit);
                             showDialog(
                               context: context,
                               builder: (BuildContext context) => AlertDialog(

--- a/lib/views/pages/account_settings/spending_limit.dart
+++ b/lib/views/pages/account_settings/spending_limit.dart
@@ -1,14 +1,21 @@
 import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:sun_flutter_capstone/consts/global_style.dart';
 import 'package:sun_flutter_capstone/controllers/spending_limit_controller.dart';
 import 'package:sun_flutter_capstone/views/widgets/input/input_field.dart';
 import 'package:sun_flutter_capstone/views/widgets/input/input_group.dart';
 import 'package:sun_flutter_capstone/views/widgets/buttons/outline_button_text.dart';
 
-class SpendingLimit extends StatelessWidget {
+class SpendingLimit extends ConsumerStatefulWidget {
   final String amount;
 
   const SpendingLimit({Key? key, this.amount = '0.0'}) : super(key: key);
+
+  @override
+  _SpendingLimitState createState() => _SpendingLimitState();
+}
+
+class _SpendingLimitState extends ConsumerState<SpendingLimit> {
 
   @override
   Widget build(BuildContext context) {
@@ -52,7 +59,7 @@ class SpendingLimit extends StatelessWidget {
                         InputGroup(
                           label: 'Update spending limit this month',
                           input: InputField(
-                            hintText: '$currency $amount',
+                            hintText: '$currency ${widget.amount}',
                             inputType: TextInputType.number,
                             inputController: amountController,
                           ),
@@ -64,13 +71,7 @@ class SpendingLimit extends StatelessWidget {
                             Navigator.of(context).pop();
                             await spendingLimitController
                                 .upsert(double.parse(amountController.text));
-                            showDialog(
-                              context: context,
-                              builder: (BuildContext context) => AlertDialog(
-                                content: Text(
-                                    'Values: $currency ${amountController.text}'),
-                              ),
-                            );
+                            ref.read(spendingLimitProvider.notifier).getSpendingLimit();
                           },
                         ),
                       ],

--- a/lib/views/widgets/navigation/bottom_navbar.dart
+++ b/lib/views/widgets/navigation/bottom_navbar.dart
@@ -15,7 +15,7 @@ class BottomNavBar extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     bool keyboardIsOpened = MediaQuery.of(context).viewInsets.bottom != 0.0;
     return AutoTabsScaffold(
-      routes: const [
+      routes: [
         DashboardRouter(),
         TransactionRouter(),
         NotificationsRouter(),


### PR DESCRIPTION
## Related Links:
- [Notion link](https://www.notion.so/Account-Implement-Spending-limit-setting-14bd6869453d4ea4b0ed8ddd920d4e92)

## Definition of Done
- [ ] Upon inputting spending limit it will save the DB
   - Table: `spending_limit`
   - column: `amount`


## Notes:
- Steps to check db:
  - To check database:
  - Open the project in Android Studio
  - Run the application to open in an emulator
  - In Android Studio, go to View > Tool Windows > Device File Explorer from the Toolbar
  - Go to /data/data/com.example.sun_flutter_capstone/databases directory
  - Right click on file dbexpense.db and save the file
  - Open the file in a database manager or online (http://extendsclass.com/sqlite-browser.html#)
  - Click on Account table


## Screenshots
![image](https://user-images.githubusercontent.com/89514595/165520441-ed9a5bdc-4156-4bde-ad7d-5bed954e8b9c.png)
![image](https://user-images.githubusercontent.com/89514595/165520608-b0dcdd50-0ff1-4fbb-bb61-363f9c3ae16c.png)

## Test View  Points
- [ ] Input a value in the input field it will reflect in DB
