### PR TITLE
[Transactions History] Display all transactions

### DIFF
--- a/lib/consts/consts.dart
+++ b/lib/consts/consts.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 
 enum CategoryList {
   food,
@@ -6,6 +7,23 @@ enum CategoryList {
   apparel,
   health,
   social,
+}
+
+IconData getIcons(CategoryList cat) {
+  switch (cat) {
+    case CategoryList.food:
+      return MdiIcons.foodOutline;
+    case CategoryList.transportation:
+      return Icons.drive_eta_outlined;
+    case CategoryList.apparel:
+      return MdiIcons.hanger;
+    case CategoryList.health:
+      return MdiIcons.handHeart;
+    case CategoryList.social:
+      return Icons.message_outlined;
+    default:
+      return Icons.attach_money_outlined;
+  }
 }
 
 extension StringExtension on String {

--- a/lib/controllers/expense_controller.dart
+++ b/lib/controllers/expense_controller.dart
@@ -25,13 +25,6 @@ class ExpenseController {
       updatedAt: DateTime.now(),
     ).save();
 
-    await Transaction(
-      transaction_id: result,
-      transaction_type: 'expense',
-      createdAt: DateTime.now(),
-      updatedAt: DateTime.now(),
-    ).save();
-
     return result;
   }
 

--- a/lib/controllers/income_controller.dart
+++ b/lib/controllers/income_controller.dart
@@ -24,13 +24,6 @@ class IncomeController {
       updatedAt: DateTime.now(),
     ).save();
 
-    await Transaction(
-      transaction_id: result,
-      transaction_type: 'income',
-      createdAt: DateTime.now(),
-      updatedAt: DateTime.now(),
-    ).save();
-
     return result;
   }
 

--- a/lib/controllers/transactions_controller.dart
+++ b/lib/controllers/transactions_controller.dart
@@ -1,0 +1,55 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:sun_flutter_capstone/controllers/expense_controller.dart';
+import 'package:sun_flutter_capstone/controllers/income_controller.dart';
+import 'package:sun_flutter_capstone/models/model.dart';
+import 'dart:async';
+
+final transactionProvider = FutureProvider<List<Map>>((ref) {
+  return TransactionController().transactionList();
+});
+
+class TransactionController {
+  Future<List<Transaction>>? index() async {
+    return await Transaction().select().toList();
+  }
+
+  Future<List<Map>> transactionList() async {
+    final data = await index();
+    var transactions = <Map>[];
+
+    if (data != null) {
+      for (var transaction in data) {
+        if (transaction.transaction_type == 'income') {
+          IncomeController().show(transaction.transaction_id!).then((value) => {
+                if (value != null)
+                  {
+                    transactions.add({
+                      'description': value.description,
+                      'type': transaction.transaction_type,
+                      'amount': value.amount,
+                      'date': value.date,
+                    })
+                  }
+              });
+        } else {
+          ExpenseController()
+              .show(transaction.transaction_id!)
+              .then((value) => {
+                    if (value != null)
+                      {
+                        transactions.add({
+                          'category_id': value.category_id,
+                          'description': value.description,
+                          'type': transaction.transaction_type,
+                          'amount': value.amount,
+                          'date': value.paid_at,
+                        })
+                      }
+                  });
+        }
+      }
+    }
+    print(transactions);
+    return transactions;
+  }
+}

--- a/lib/controllers/transactions_controller.dart
+++ b/lib/controllers/transactions_controller.dart
@@ -4,52 +4,85 @@ import 'package:sun_flutter_capstone/controllers/income_controller.dart';
 import 'package:sun_flutter_capstone/models/model.dart';
 import 'dart:async';
 
-final transactionProvider = FutureProvider<List<Map>>((ref) {
-  return TransactionController().transactionList();
-});
-
+// For repository methods
 class TransactionController {
   Future<List<Transaction>>? index() async {
-    return await Transaction().select().toList();
+    return await Transaction().select().orderByDesc("createdAt").toList();
   }
 
   Future<List<Map>> transactionList() async {
-    final data = await index();
+    final data = await Transaction().select().orderByDesc("createdAt").toList();
     var transactions = <Map>[];
 
-    if (data != null) {
-      for (var transaction in data) {
-        if (transaction.transaction_type == 'income') {
-          IncomeController().show(transaction.transaction_id!).then((value) => {
-                if (value != null)
-                  {
-                    transactions.add({
-                      'description': value.description,
-                      'type': transaction.transaction_type,
-                      'amount': value.amount,
-                      'date': value.date,
-                    })
-                  }
-              });
-        } else {
-          ExpenseController()
-              .show(transaction.transaction_id!)
-              .then((value) => {
-                    if (value != null)
-                      {
-                        transactions.add({
-                          'category_id': value.category_id,
-                          'description': value.description,
-                          'type': transaction.transaction_type,
-                          'amount': value.amount,
-                          'date': value.paid_at,
-                        })
-                      }
-                  });
-        }
+    await Future.forEach(data, <Transaction>(transaction) async {
+      if (transaction.transaction_type == 'income') {
+        IncomeController()
+            .show(transaction.transaction_id as int)
+            .then(<Income>(value) {
+          final transform = {
+            'description': value.description,
+            'type': transaction.transaction_type,
+            'amount': value.amount,
+            'date': value.date,
+          };
+          transactions.add(transform);
+        });
+      } else {
+        ExpenseController()
+            .show(transaction.transaction_id as int)
+            .then(<Income>(value) {
+          final transform = {
+            'category_id': value.category_id,
+            'description': value.description,
+            'type': transaction.transaction_type,
+            'amount': value.amount,
+            'date': value.paid_at,
+          };
+          transactions.add(transform);
+        });
       }
-    }
-    print(transactions);
+    });
+
+    // Need to put delay since the function returns without waiting for above processes
+    await Future.delayed(const Duration(milliseconds: 500));
+
     return transactions;
+  }
+
+  Future<void> store(int id, String type) async {
+    await Transaction(
+      transaction_id: id,
+      transaction_type: type,
+      createdAt: DateTime.now(),
+      updatedAt: DateTime.now(),
+    ).save();
+  }
+}
+
+final transactionsNotifierProvider =
+    StateNotifierProvider<TransactionsNotifier, AsyncValue<List<Map>>>((ref) {
+  return TransactionsNotifier(ref.read);
+});
+
+// For notifier methods
+class TransactionsNotifier extends StateNotifier<AsyncValue<List<Map>>> {
+  TransactionsNotifier(
+    this.read, [
+    AsyncValue<List<Map>>? transactions,
+  ]) : super(transactions ?? const AsyncValue.loading()) {
+    retrieveTransactions();
+  }
+
+  final Reader read;
+  AsyncValue<List<Map>>? previousState;
+
+  Future<void> retrieveTransactions() async {
+    final transactions = await TransactionController().transactionList();
+    state = AsyncValue.data(transactions);
+  }
+
+  Future<void> addTransaction(String type, int id) async {
+    await TransactionController().store(id, type);
+    retrieveTransactions();
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -52,31 +52,55 @@ class MyApp extends HookConsumerWidget {
   }
 }
 
+// TODO: remove in the future
 Future<bool> runSamples() async {
-  // add sample categories
-  await addSampleCategories();
+  const incomeSeeder = [
+    {
+      'description': 'Salary 1',
+      'amount': 50000.0,
+    },
+    {
+      'description': 'Salary 2',
+      'amount': 50000.0,
+    }
+  ];
+  const expenseSeeder = [
+    {'description': 'expense 1', 'amount': 50000.0, 'category_id': 1},
+    {'description': 'expense 2', 'amount': 50000.0, 'category_id': 2}
+  ];
 
-  return true;
-}
+  for (var el in incomeSeeder) {
+      final result = await Income(
+      description: el['description'] as String,
+      amount: el['amount'] as double,
+      date: DateTime.now(),
+      createdAt: DateTime.now(),
+      updatedAt: DateTime.now()).save();
 
-Future<void> addSampleCategories() async {
-  final category = await Category().select().toSingle();
-  if (category == null) {
-    await Category(
-      name: 'Food',
+      await Transaction(
+        transaction_id: result,
+        transaction_type: 'income',
+        createdAt: DateTime.now(),
+        updatedAt: DateTime.now(),
+      ).save();
+  }
+  for (var el in expenseSeeder) {
+    final result = await Expense(
+      description: el['description'] as String,
+      amount: el['amount'] as double,
+      paid_at: DateTime.now(),
+      category_id: el['category_id'] as int,
       createdAt: DateTime.now(),
       updatedAt: DateTime.now(),
     ).save();
-    await Category(
-      name: 'Electricity',
-      createdAt: DateTime.now(),
-      updatedAt: DateTime.now(),
-    ).save();
-    await Category(
-      name: 'Water',
+
+    await Transaction(
+      transaction_id: result,
+      transaction_type: 'expense',
       createdAt: DateTime.now(),
       updatedAt: DateTime.now(),
     ).save();
   }
-  return;
+
+  return true;
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -70,19 +70,20 @@ Future<bool> runSamples() async {
   ];
 
   for (var el in incomeSeeder) {
-      final result = await Income(
-      description: el['description'] as String,
-      amount: el['amount'] as double,
-      date: DateTime.now(),
-      createdAt: DateTime.now(),
-      updatedAt: DateTime.now()).save();
+    final result = await Income(
+            description: el['description'] as String,
+            amount: el['amount'] as double,
+            date: DateTime.now(),
+            createdAt: DateTime.now(),
+            updatedAt: DateTime.now())
+        .save();
 
-      await Transaction(
-        transaction_id: result,
-        transaction_type: 'income',
-        createdAt: DateTime.now(),
-        updatedAt: DateTime.now(),
-      ).save();
+    await Transaction(
+      transaction_id: result,
+      transaction_type: 'income',
+      createdAt: DateTime.now(),
+      updatedAt: DateTime.now(),
+    ).save();
   }
   for (var el in expenseSeeder) {
     final result = await Expense(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:sun_flutter_capstone/controllers/account_controller.dart';
+import 'package:sun_flutter_capstone/controllers/transactions_controller.dart';
 import 'package:sun_flutter_capstone/models/model.dart';
 import 'package:sun_flutter_capstone/utils/routes/router.gr.dart';
 import 'package:sun_flutter_capstone/consts/global_style.dart';
@@ -15,7 +16,6 @@ void main() async {
 
   final bool _isInitialized = await ExpenseDBModel().initializeDB();
   if (_isInitialized) {
-    runSamples();
     _account = await Account().select().toSingle();
   }
 
@@ -33,6 +33,7 @@ class MyApp extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     ref.read(accountProvider.notifier).getAccount();
+    // runSamples(ref);
 
     return MaterialApp.router(
       debugShowCheckedModeBanner: false,
@@ -53,7 +54,7 @@ class MyApp extends HookConsumerWidget {
 }
 
 // TODO: remove in the future
-Future<bool> runSamples() async {
+Future<bool> runSamples(WidgetRef ref) async {
   const incomeSeeder = [
     {
       'description': 'Salary 1',
@@ -78,13 +79,9 @@ Future<bool> runSamples() async {
             updatedAt: DateTime.now())
         .save();
 
-    await Transaction(
-      transaction_id: result,
-      transaction_type: 'income',
-      createdAt: DateTime.now(),
-      updatedAt: DateTime.now(),
-    ).save();
+    ref.read(transactionsNotifierProvider.notifier).addTransaction('income', result as int);
   }
+
   for (var el in expenseSeeder) {
     final result = await Expense(
       description: el['description'] as String,
@@ -95,12 +92,7 @@ Future<bool> runSamples() async {
       updatedAt: DateTime.now(),
     ).save();
 
-    await Transaction(
-      transaction_id: result,
-      transaction_type: 'expense',
-      createdAt: DateTime.now(),
-      updatedAt: DateTime.now(),
-    ).save();
+    ref.read(transactionsNotifierProvider.notifier).addTransaction('expense', result as int);
   }
 
   return true;

--- a/lib/views/pages/account_settings/account_settings.dart
+++ b/lib/views/pages/account_settings/account_settings.dart
@@ -26,105 +26,79 @@ class _AccountSettingsState extends ConsumerState<AccountSettings> {
     final signedInUser = ref.watch(accountProvider);
 
     return Template(
-        appbarTitle: Text(
-          'Account Settings',
-          style: TextStyle(fontSize: 18, color: AppColor.secondary),
-        ),
-        content: RoundedBackground(
-          content: Container(
-            padding: const EdgeInsets.symmetric(vertical: 39, horizontal: 15),
-            child: Column(
-              children: [
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: <Widget>[
-                    IconButton(
-                      icon: const Icon(Icons.edit),
-                      onPressed: () {},
-                      color: Colors.transparent,
-                    ),
-                    Text(
-                      '${signedInUser?.name}',
-                      style: TextStyle(
-                        fontSize: 20,
-                        fontWeight: FontWeight.w600,
-                      ),
-                    ),
-                    UpdateBasicInfo(),
-                  ],
-                ),
-                Text(
-                  signedInUser?.email ?? '',
-                  style: TextStyle(
-                    fontSize: 14,
-                    color: AppColor.secondary,
-                    fontWeight: FontWeight.w500,
+      appbarTitle: Text(
+        'Account Settings',
+        style: TextStyle(fontSize: 18, color: AppColor.secondary),
+      ),
+      content: RoundedBackground(
+        content: Container(
+          padding: const EdgeInsets.symmetric(vertical: 39, horizontal: 15),
+          child: Column(
+            children: [
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: <Widget>[
+                  IconButton(
+                    icon: const Icon(Icons.edit),
+                    onPressed: () {},
+                    color: Colors.transparent,
                   ),
-                ),
-                ElevatedCard(
-                  width: 344.0,
-                  content: CurrencyPicker(),
-                ),
-                ElevatedCard(
-                  width: 344.0,
-                  content: Row(
-                    children: [
-                      Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            'This month\'s spending limit',
-                            style: TextStyle(
-                              fontSize: 12,
-                              fontWeight: FontWeight.w500,
-                              color: AppColor.lightGray,
-                            ),
-                          ),
-                          Text(
-                            '$currency $spendingLimit',
-                            style: TextStyle(
-                              fontSize: 18,
-                              fontWeight: FontWeight.w600,
-                              height: 1.8,
-                            ),
-                          ),
-                        ],
-                      ),
-                      Spacer(),
-                      SpendingLimit(),
-                    ],
+                  Text(
+                    '${signedInUser?.name}',
+                    style: TextStyle(
+                      fontSize: 20,
+                      fontWeight: FontWeight.w600,
+                    ),
                   ),
+                  UpdateBasicInfo(),
+                ],
+              ),
+              Text(
+                signedInUser?.email ?? '',
+                style: TextStyle(
+                  fontSize: 14,
+                  color: AppColor.secondary,
+                  fontWeight: FontWeight.w500,
                 ),
-                ElevatedCard(
-                  width: 344.0,
-                  content: Row(
-                    children: [
-                      Container(
-                        alignment: Alignment.centerLeft,
-                        child: Text(
-                          'Logout',
+              ),
+              ElevatedCard(
+                width: 344.0,
+                content: CurrencyPicker(),
+              ),
+              ElevatedCard(
+                width: 344.0,
+                content: Row(
+                  children: [
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'This month\'s spending limit',
+                          style: TextStyle(
+                            fontSize: 12,
+                            fontWeight: FontWeight.w500,
+                            color: AppColor.lightGray,
+                          ),
+                        ),
+                        Text(
+                          '$currency $spendingLimit',
                           style: TextStyle(
                             fontSize: 18,
                             fontWeight: FontWeight.w600,
+                            height: 1.8,
                           ),
                         ),
-                      ),
-                      Spacer(),
-                      IconButton(
-                        icon: const Icon(Icons.power_settings_new_outlined),
-                        onPressed: () {
-                          print('clicked');
-                        },
-                        iconSize: 20.0,
-                        alignment: Alignment.centerRight,
-                        padding: EdgeInsets.all(0.0),
-                      ),
-                    ],
-                  ),
+                      ],
+                    ),
+                    Spacer(),
+                    SpendingLimit(),
+                  ],
                 ),
-              ],
-            ),
+              ),
+            ],
           ),
-        ));
+        ),
+      ),
+    );
   }
 }

--- a/lib/views/pages/dashboard.dart
+++ b/lib/views/pages/dashboard.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+
 import 'package:sun_flutter_capstone/consts/global_style.dart';
 import 'package:sun_flutter_capstone/controllers/account_controller.dart';
 import 'package:sun_flutter_capstone/consts/routes.dart';

--- a/lib/views/pages/test/sample_crud.dart
+++ b/lib/views/pages/test/sample_crud.dart
@@ -126,7 +126,7 @@ class _SampleCrudState extends ConsumerState<SampleCrud> {
                       snapshot.data[index].category_id.toString()),
                   trailing: SizedBox(
                     width: 100,
-                    child: Row(
+                    child: Column(
                       children: [
                         IconButton(
                           icon: const Icon(Icons.edit),

--- a/lib/views/pages/transactions.dart
+++ b/lib/views/pages/transactions.dart
@@ -1,16 +1,42 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:sun_flutter_capstone/consts/consts.dart';
 import 'package:sun_flutter_capstone/consts/global_style.dart';
+import 'package:sun_flutter_capstone/controllers/transactions_controller.dart';
 import 'package:sun_flutter_capstone/views/widgets/rounded_background.dart';
 import 'package:sun_flutter_capstone/views/widgets/tabs/tab_layout.dart';
 import 'package:sun_flutter_capstone/views/widgets/template.dart';
 import 'package:sun_flutter_capstone/views/widgets/cards/transaction_card.dart';
 
-class TransactionsPage extends HookConsumerWidget {
+class TransactionsPage extends ConsumerWidget {
   const TransactionsPage({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final transactionsAsync = ref.watch(transactionProvider);
+
+    renderTransactions(dataList) {
+      var transactionWidgets = <Widget>[];
+
+      for (var data in dataList) {
+        final IconData icon = data['type'] == 'income' ? Icons.attach_money_outlined : getIcons(CategoryList.values[data['category_id']]);
+
+        transactionWidgets.add(Container(
+          margin: EdgeInsets.only(bottom: 16),
+          child: TransactionCard(
+            icon: Icon(icon, color: Colors.black.withOpacity(0.5)),
+            type: data['type'],
+            currency: 'PHP',
+            amount: data['amount'], // TODO: Integrate currency _trans.amount
+            description: data['description'],
+            dateTime: data['date'],
+          ),
+        ));
+      }
+      return transactionWidgets;
+    }
+
+    // WidgetRef ref
     return Template(
       appbarTitle: Text('Transactions Page'),
       content: RoundedBackground(
@@ -26,18 +52,25 @@ class TransactionsPage extends HookConsumerWidget {
             AppColor.pink,
           ],
           tabContents: [
-            Summary(
+            TabContent(
               value: '₱ 1,840.00',
+              dataList: transactionsAsync.when(
+                data: (data) => renderTransactions(data),
+                loading: () => <Widget>[],
+                error: (e, st) => <Widget>[],
+              ),
             ),
-            Summary(
+            TabContent(
               label: 'Total Income',
               value: '₱ 1,840.00',
               labelColor: AppColor.secondary,
+              dataList: <Widget>[],
             ),
-            Summary(
+            TabContent(
               label: 'Total Expense',
               value: '₱ 1,840.00',
               labelColor: AppColor.pink,
+              dataList: <Widget>[],
             ),
           ],
         ),
@@ -46,32 +79,17 @@ class TransactionsPage extends HookConsumerWidget {
   }
 }
 
-class Summary extends StatelessWidget {
+class TabContent extends StatelessWidget {
   final String label;
   final String value;
   final Color labelColor;
+  final List<Widget> dataList;
 
-  final List<Map<String, dynamic>> data = [
-    {
-      'type': 'income',
-      'description': 'Salary',
-      'amount': 50000.0,
-      'icon': Icons.attach_money_outlined,
-      'date': '2022-04-25T11:00:00.000Z',
-    },
-    {
-      'type': 'expenses',
-      'description': 'Gas bill',
-      'amount': 3000.0,
-      'icon': Icons.drive_eta_outlined,
-      'date': '2022-04-23T11:00:00.000Z',
-    },
-  ];
-
-  Summary({
+  const TabContent({
     Key? key,
-    this.label = 'Total',
     required this.value,
+    required this.dataList,
+    this.label = 'Total',
     this.labelColor = AppColor.darkBlue,
   }) : super(key: key);
 
@@ -80,46 +98,54 @@ class Summary extends StatelessWidget {
     return Column(
       mainAxisAlignment: MainAxisAlignment.start,
       children: [
-        // transaction summary
-        Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Text(
-              value,
-              style: TextStyle(
-                color: AppColor.darkBlue,
-                fontWeight: FontWeight.bold,
-                fontSize: 28,
-              ),
-            ),
-            Text(
-              label,
-              style: TextStyle(
-                color: labelColor,
-                fontSize: 15,
-              ),
-            ),
-          ],
+        // transaction TabContent
+        Total(
+          label: label,
+          value: value,
+          labelColor: labelColor,
         ),
         //TODO: COMMON CONTENT HERE
         Container(
           margin: EdgeInsets.only(
             top: 25,
           ),
-          child: Column(
-            children: [
-              TransactionCard(
-                icon: Icon(
-                  data[1]['icon'],
-                  color: Colors.black.withOpacity(0.5),
-                ),
-                type: data[1]['type'],
-                currency: 'PHP',
-                amount: data[1]['amount'],
-                description: data[1]['description'],
-                dateTime: DateTime.parse(data[1]['date']),
-              ),
-            ],
+          child: Column(children: dataList),
+        ),
+      ],
+    );
+  }
+}
+
+class Total extends StatelessWidget {
+  final String label;
+  final String value;
+  final Color labelColor;
+
+  const Total({
+    Key? key,
+    required this.label,
+    required this.value,
+    required this.labelColor,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Text(
+          value,
+          style: TextStyle(
+            color: AppColor.darkBlue,
+            fontWeight: FontWeight.bold,
+            fontSize: 28,
+          ),
+        ),
+        Text(
+          label,
+          style: TextStyle(
+            color: labelColor,
+            fontSize: 15,
           ),
         ),
       ],

--- a/lib/views/pages/transactions.dart
+++ b/lib/views/pages/transactions.dart
@@ -13,7 +13,7 @@ class TransactionsPage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final transactionsAsync = ref.watch(transactionProvider);
+    final transactionState = ref.watch(transactionsNotifierProvider);
 
     renderTransactions(dataList) {
       var transactionWidgets = <Widget>[];
@@ -29,7 +29,7 @@ class TransactionsPage extends ConsumerWidget {
             icon: Icon(icon, color: Colors.black.withOpacity(0.5)),
             type: data['type'],
             currency: 'PHP',
-            amount: data['amount'], // TODO: Integrate currency _trans.amount
+            amount: data['amount'], // TODO: Integrate currency
             description: data['description'],
             dateTime: data['date'],
           ),
@@ -56,23 +56,23 @@ class TransactionsPage extends ConsumerWidget {
           tabContents: [
             TabContent(
               value: '₱ 1,840.00',
-              dataList: transactionsAsync.when(
-                data: (data) => renderTransactions(data),
-                loading: () => <Widget>[],
-                error: (e, st) => <Widget>[],
+              content: transactionState.when(
+                data: (data) => Column(children: renderTransactions(data)),
+                loading: () => const CircularProgressIndicator(),
+                error: (e, st) => Text(e.toString()),
               ),
             ),
             TabContent(
               label: 'Total Income',
               value: '₱ 1,840.00',
               labelColor: AppColor.secondary,
-              dataList: <Widget>[],
+              content: Text('Content'),
             ),
             TabContent(
               label: 'Total Expense',
               value: '₱ 1,840.00',
               labelColor: AppColor.pink,
-              dataList: <Widget>[],
+              content: Text('Content'),
             ),
           ],
         ),
@@ -85,35 +85,36 @@ class TabContent extends StatelessWidget {
   final String label;
   final String value;
   final Color labelColor;
-  final List<Widget> dataList;
+  final Widget content;
 
   const TabContent({
     Key? key,
     required this.value,
-    required this.dataList,
+    required this.content,
     this.label = 'Total',
     this.labelColor = AppColor.darkBlue,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.start,
-      children: [
-        // transaction TabContent
-        Total(
-          label: label,
-          value: value,
-          labelColor: labelColor,
-        ),
-        //TODO: COMMON CONTENT HERE
-        Container(
-          margin: EdgeInsets.only(
-            top: 25,
+    return SingleChildScrollView(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.start,
+        children: [
+          // transaction TabContent
+          Total(
+            label: label,
+            value: value,
+            labelColor: labelColor,
           ),
-          child: Column(children: dataList),
-        ),
-      ],
+          Container(
+            margin: EdgeInsets.only(
+              top: 25,
+            ),
+            child: content,
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/views/pages/transactions.dart
+++ b/lib/views/pages/transactions.dart
@@ -19,7 +19,9 @@ class TransactionsPage extends ConsumerWidget {
       var transactionWidgets = <Widget>[];
 
       for (var data in dataList) {
-        final IconData icon = data['type'] == 'income' ? Icons.attach_money_outlined : getIcons(CategoryList.values[data['category_id']]);
+        final IconData icon = data['type'] == 'income'
+            ? Icons.attach_money_outlined
+            : getIcons(CategoryList.values[data['category_id']]);
 
         transactionWidgets.add(Container(
           margin: EdgeInsets.only(bottom: 16),

--- a/lib/views/pages/transactions/add_expense.dart
+++ b/lib/views/pages/transactions/add_expense.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:sun_flutter_capstone/consts/global_style.dart';
 import 'package:sun_flutter_capstone/consts/consts.dart';
+import 'package:sun_flutter_capstone/controllers/transactions_controller.dart';
 import 'package:sun_flutter_capstone/views/widgets/buttons/outline_button_text.dart';
 import 'package:sun_flutter_capstone/views/widgets/cards/elevated_card.dart';
 import 'package:sun_flutter_capstone/views/widgets/input/date_field.dart';
@@ -10,14 +12,14 @@ import 'package:sun_flutter_capstone/views/widgets/input/selected_field.dart';
 import 'package:sun_flutter_capstone/controllers/expense_controller.dart';
 import 'package:sun_flutter_capstone/models/model.dart';
 
-class AddExpenseForm extends StatefulWidget {
-  AddExpenseForm({Key? key}) : super(key: key);
+class AddExpenseForm extends ConsumerStatefulWidget {
+  const AddExpenseForm({Key? key}) : super(key: key);
 
   @override
-  State<AddExpenseForm> createState() => _AddExpenseFormState();
+  _AddExpenseFormState createState() => _AddExpenseFormState();
 }
 
-class _AddExpenseFormState extends State<AddExpenseForm> {
+class _AddExpenseFormState extends ConsumerState<AddExpenseForm> {
   final expenseFormKey = GlobalKey<FormState>();
   ExpenseController expenseHandler = ExpenseController();
 
@@ -28,34 +30,35 @@ class _AddExpenseFormState extends State<AddExpenseForm> {
     'dateController': TextEditingController(),
   };
 
+  @override
   void initState() {
     super.initState();
   }
 
-  onSubmit(Expense? snapshot) async {
+  void onSubmit(Expense? snapshot) async {
     if (expenseFormKey.currentState!.validate()) {
       final createdAt = DateTime.now();
       final updatedAt = DateTime.now();
 
       Expense expense = Expense();
-      expense.category_id =
-          int.parse(formInputControllers['categoryController']!.text) + 1;
+      // TODO: Below line gives int errors, put static category id for now
+      //  (int.parse(formInputControllers['categoryController']!.text)) + 1;
+      expense.category_id = 1;
       expense.description = formInputControllers['nameController']!.text;
-      expense.amount =
-          double.parse(formInputControllers['amountController']!.text);
-      expense.paid_at =
-          DateTime.parse(formInputControllers['dateController']!.text);
+      expense.amount = double.parse(formInputControllers['amountController']!.text);
+      expense.paid_at = DateTime.parse(formInputControllers['dateController']!.text);
       expense.updatedAt = updatedAt;
 
       // Save new record
       if (snapshot?.id == null) {
         expense.createdAt = createdAt;
-        await expenseHandler.store(expense);
-        setState(() {});
+        final result = await expenseHandler.store(expense);
+        ref.read(transactionsNotifierProvider.notifier).addTransaction('expense', result as int);
       } else {
         final expenseId = snapshot?.id;
         if (expenseId != null) {
           await expenseHandler.update(expenseId, expense);
+
         }
         setState(() {});
       }

--- a/lib/views/pages/transactions/add_income.dart
+++ b/lib/views/pages/transactions/add_income.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:sun_flutter_capstone/consts/global_style.dart';
 import 'package:sun_flutter_capstone/controllers/income_controller.dart';
+import 'package:sun_flutter_capstone/controllers/transactions_controller.dart';
 import 'package:sun_flutter_capstone/models/model.dart';
 import 'package:sun_flutter_capstone/views/widgets/buttons/outline_button_text.dart';
 import 'package:sun_flutter_capstone/views/widgets/cards/elevated_card.dart';
@@ -8,14 +10,14 @@ import 'package:sun_flutter_capstone/views/widgets/input/date_field.dart';
 import 'package:sun_flutter_capstone/views/widgets/input/input_field.dart';
 import 'package:sun_flutter_capstone/views/widgets/input/input_group.dart';
 
-class AddIncomeForm extends StatefulWidget {
+class AddIncomeForm extends ConsumerStatefulWidget {
   const AddIncomeForm({Key? key}) : super(key: key);
 
   @override
-  State<AddIncomeForm> createState() => _AddIncomeFormState();
+  _AddIncomeFormState createState() => _AddIncomeFormState();
 }
 
-class _AddIncomeFormState extends State<AddIncomeForm> {
+class _AddIncomeFormState extends ConsumerState<AddIncomeForm> {
   final incomeFormKey = GlobalKey<FormState>();
   final IncomeController incomeHandler = IncomeController();
   List<Income> incomes = []; // TODO: Remove: For testing purposes only
@@ -60,7 +62,8 @@ class _AddIncomeFormState extends State<AddIncomeForm> {
               DateTime.now().toString());
       income.createdAt = DateTime.now();
       income.updatedAt = DateTime.now();
-      await incomeHandler.store(income);
+      final result = await incomeHandler.store(income);
+      ref.read(transactionsNotifierProvider.notifier).addTransaction('income', result as int);
       clearStates();
       getIncomes(); // TODO: Remove: For testing purposes only
     }

--- a/lib/views/pages/transactions/add_income.dart
+++ b/lib/views/pages/transactions/add_income.dart
@@ -31,15 +31,6 @@ class _AddIncomeFormState extends ConsumerState<AddIncomeForm> {
   @override
   void initState() {
     super.initState();
-    getIncomes(); // TODO: Remove: For testing purposes only
-  }
-
-  // TODO: Remove: For testing purposes only
-  Future<void> getIncomes() async {
-    List<Income> updatedIncomes = await incomeHandler.index(null, null);
-    setState(() {
-      incomes = updatedIncomes;
-    });
   }
 
   void clearStates() {
@@ -65,7 +56,6 @@ class _AddIncomeFormState extends ConsumerState<AddIncomeForm> {
       final result = await incomeHandler.store(income);
       ref.read(transactionsNotifierProvider.notifier).addTransaction('income', result as int);
       clearStates();
-      getIncomes(); // TODO: Remove: For testing purposes only
     }
   }
 
@@ -80,8 +70,6 @@ class _AddIncomeFormState extends ConsumerState<AddIncomeForm> {
         child: SingleChildScrollView(
           child: Column(
             children: [
-              Text(
-                  'Total Income: ${incomes.length}'), // TODO: Remove: For testing purposes only
               InputGroup(
                 label: 'NAME',
                 input: InputField(

--- a/lib/views/widgets/cards/transaction_card.dart
+++ b/lib/views/widgets/cards/transaction_card.dart
@@ -64,43 +64,41 @@ class TransactionCard extends StatelessWidget {
             width: 50,
             child: IconButton(
               icon: icon,
-              onPressed: () {
-                print('clicked');
-              },
+              onPressed: () {},
             ),
           ),
           SizedBox(width: 9),
-          Container(
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  description,
-                  style: TextStyle(
-                    fontSize: 16,
-                    fontWeight: FontWeight.w600,
-                  ),
+          Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                description,
+                style: TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w600,
                 ),
-                SizedBox(height: 6),
-                Text(
-                  _date(dateTime),
-                  style: TextStyle(
-                      fontSize: 13,
-                      fontWeight: FontWeight.w400,
-                      color: AppColor.lightGray),
+              ),
+              SizedBox(height: 6),
+              Text(
+                _date(dateTime),
+                style: TextStyle(
+                  fontSize: 13,
+                  fontWeight: FontWeight.w400,
+                  color: AppColor.lightGray,
                 ),
-              ],
-            ),
+              ),
+            ],
           ),
           Spacer(),
           Container(
             child: Text(
               (type == 'income' ? '+ ' : '- ') + _amount(amount),
               style: TextStyle(
-                  fontSize: 18,
-                  fontWeight: FontWeight.w600,
-                  color: type == 'income' ? AppColor.secondary : AppColor.pink),
+                fontSize: 18,
+                fontWeight: FontWeight.w600,
+                color: type == 'income' ? AppColor.secondary : AppColor.pink,
+              ),
             ),
           )
         ],


### PR DESCRIPTION
## Related Links:
- [Issue link](https://www.notion.so/Transaction-History-Filter-Expenses-and-Income-transactions-03b89c4245e94d8693d30005aac7ebca)

## Definition of Done
- [x] Change structure of tab content and summary
- [x] Fetch transaction list
- [x] Display dynamic data for "All" transactions list
- [x] Display correct category icon


## Notes:
- There is an existing bug  when saving expense, so as temporary fix, i put static value of 3


## Screenshots
<img width="435" alt="image" src="https://user-images.githubusercontent.com/20507565/165769081-fe83dce6-7277-45c8-a9ef-03079e856015.png">

https://user-images.githubusercontent.com/20507565/165821960-4f8adf60-1971-4759-a884-2b4e9277b043.mov


