### PR TITLE
Make spending limit dynamic

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:sun_flutter_capstone/controllers/account_controller.dart';
+import 'package:sun_flutter_capstone/controllers/spending_limit_controller.dart';
 import 'package:sun_flutter_capstone/controllers/transactions_controller.dart';
 import 'package:sun_flutter_capstone/models/model.dart';
 import 'package:sun_flutter_capstone/utils/routes/router.gr.dart';
@@ -33,6 +34,7 @@ class MyApp extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     ref.read(accountProvider.notifier).getAccount();
+    ref.read(spendingLimitProvider.notifier).getSpendingLimit();
     // runSamples(ref);
 
     return MaterialApp.router(

--- a/lib/views/pages/dashboard.dart
+++ b/lib/views/pages/dashboard.dart
@@ -5,8 +5,8 @@ import 'package:sun_flutter_capstone/consts/consts.dart';
 import 'package:sun_flutter_capstone/consts/global_style.dart';
 import 'package:sun_flutter_capstone/controllers/account_controller.dart';
 import 'package:sun_flutter_capstone/consts/routes.dart';
+import 'package:sun_flutter_capstone/controllers/spending_limit_controller.dart';
 import 'package:sun_flutter_capstone/controllers/transactions_controller.dart';
-import 'package:sun_flutter_capstone/state/spending_provider.dart';
 import 'package:sun_flutter_capstone/utils/routing.dart';
 import 'package:sun_flutter_capstone/views/pages/transaction_summary.dart';
 import 'package:sun_flutter_capstone/views/widgets/progress_bar.dart';
@@ -23,72 +23,6 @@ class Dashboard extends StatefulHookConsumerWidget {
   final String firstName = 'Juan Dela';
   final String lastName = 'Dela Cruz';
   final String currency = 'fil';
-
-  final List<Map<String, dynamic>> data = const [
-    {
-      'type': 'income',
-      'description': 'Salary',
-      'amount': 50000.0,
-      'icon': Icons.attach_money_outlined,
-      'date': '2022-04-25T11:00:00.000Z',
-    },
-    {
-      'type': 'expenses',
-      'description': 'Gas bill',
-      'amount': 3000.0,
-      'icon': Icons.drive_eta_outlined,
-      'date': '2022-04-23T11:00:00.000Z',
-    },
-    {
-      'type': 'expenses',
-      'description': 'Gas bill',
-      'amount': 3000.0,
-      'icon': Icons.drive_eta_outlined,
-      'date': '2022-04-23T11:00:00.000Z',
-    },
-    {
-      'type': 'expenses',
-      'description': 'Gas bill',
-      'amount': 3000.0,
-      'icon': Icons.drive_eta_outlined,
-      'date': '2022-04-23T11:00:00.000Z',
-    },
-    {
-      'type': 'expenses',
-      'description': 'Gas bill',
-      'amount': 3000.0,
-      'icon': Icons.drive_eta_outlined,
-      'date': '2022-04-23T11:00:00.000Z',
-    },
-    {
-      'type': 'expenses',
-      'description': 'Gas bill',
-      'amount': 3000.0,
-      'icon': Icons.drive_eta_outlined,
-      'date': '2022-04-23T11:00:00.000Z',
-    },
-    {
-      'type': 'expenses',
-      'description': 'Gas bill',
-      'amount': 3000.0,
-      'icon': Icons.drive_eta_outlined,
-      'date': '2022-04-23T11:00:00.000Z',
-    },
-    {
-      'type': 'expenses',
-      'description': 'Gas bill',
-      'amount': 3000.0,
-      'icon': Icons.drive_eta_outlined,
-      'date': '2022-04-23T11:00:00.000Z',
-    },
-    {
-      'type': 'expenses',
-      'description': 'Gas bill',
-      'amount': 3000.0,
-      'icon': Icons.drive_eta_outlined,
-      'date': '2022-04-23T11:00:00.000Z',
-    },
-  ];
 
   String _greeting() {
     var hour = DateTime.now().hour;
@@ -154,7 +88,16 @@ class _DashboardState extends ConsumerState<Dashboard> {
   @override
   Widget build(BuildContext context) {
     final signedInAccount = ref.watch(accountProvider);
-    final spendingAmount = ref.watch(spendingProvider);
+    final spendingLimit = ref.watch(spendingLimitProvider);
+
+    double getLimit() {
+      double total = totalExpense / spendingLimit;
+
+      if (spendingLimit == 0) return 0;
+      if (total > 1) return 1;
+
+      return total;
+    }
 
     return Template(
       automaticallyImplyLeading: false,
@@ -186,35 +129,17 @@ class _DashboardState extends ConsumerState<Dashboard> {
                   currency: signedInAccount?.currency ?? 'PHP',
                 ),
                 Container(
-                  margin:
-                      EdgeInsets.only(top: 35, left: 20, right: 20, bottom: 10),
-                  child: ProgressBar(
-                    progress: spendingAmount,
-                    label: "You have spent",
-                  ),
-                ),
-                // * The following row can be removed this is just for testing the progress bar
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    Flexible(
-                      child: ElevatedButton(
-                        onPressed: () {
-                          setSpendingAmount(ref, spendingAmount - 0.1);
-                        },
-                        child: const Text('-'),
-                      ),
-                    ),
-                    const SizedBox(width: 30),
-                    Flexible(
-                      child: ElevatedButton(
-                        onPressed: () {
-                          setSpendingAmount(ref, spendingAmount + 0.1);
-                        },
-                        child: const Text('+'),
-                      ),
-                    )
-                  ],
+                  margin: EdgeInsets.only(
+                      top: (spendingLimit == 0) ? 0 : 35,
+                      left: 20,
+                      right: 20,
+                      bottom: (spendingLimit == 0) ? 0 : 10),
+                  child: (spendingLimit == 0)
+                      ? Text('')
+                      : ProgressBar(
+                          progress: getLimit(),
+                          label: "You have spent",
+                        ),
                 ),
                 // Recent transactions
                 Container(

--- a/lib/views/widgets/progress_bar.dart
+++ b/lib/views/widgets/progress_bar.dart
@@ -62,9 +62,11 @@ class _ProgressBarState extends ConsumerState<ProgressBar>
 
   List<Text> getPercentValues(double progress) {
     double fillValue = progress * 100;
+    String remainingPercetage =
+        (fillValue == 0) ? '100.0 %' : doubleToPercent(100 - fillValue);
     return [
-      styleText(doubleToPercent(fillValue), true),
-      styleText(doubleToPercent(100 - fillValue), false),
+      styleText(doubleToPercent(fillValue), false),
+      styleText(remainingPercetage, false),
     ];
   }
 


### PR DESCRIPTION
## Related Links:
- Issue link: https://www.notion.so/Dashboard-Calculate-spending-limit-percentage-for-the-current-month-d1d17f01c4804cb2b5de30e823f77b3b

## Definition of Done
- [x]  Delete the buttons (+ and -)
- [x]  Calculate sum of this month’s expenses
    - If current date is April, then get from April 1 to April 30
- [x]  Fetch this month’s spending limit
- [x]  Calculate percentage of spent money fro the budget
    - (Total of expenses / Spending limit) * 100

## Notes:
- N/A

## Screenshots

https://user-images.githubusercontent.com/88467532/165872321-fc6af126-d083-4843-94b8-2a5fa09bb50a.mp4

## Test View  Points
- (Check Definition of Done)
