### PR TITLE
[Bugfix] Disable Notification Icon

### DIFF
--- a/lib/views/widgets/navigation/bottom_navbar.dart
+++ b/lib/views/widgets/navigation/bottom_navbar.dart
@@ -62,7 +62,7 @@ class BottomNavBar extends HookConsumerWidget {
                 NavigationButton(
                   icon: Icons.notifications_none_outlined,
                   activeIcon: Icons.notifications_active,
-                  route: Routes.notifications,
+                  route: null,
                 ),
                 NavigationButton(
                   icon: Icons.settings_outlined,

--- a/lib/views/widgets/navigation/bottom_navbar.dart
+++ b/lib/views/widgets/navigation/bottom_navbar.dart
@@ -62,6 +62,7 @@ class BottomNavBar extends HookConsumerWidget {
                 NavigationButton(
                   icon: Icons.notifications_none_outlined,
                   activeIcon: Icons.notifications_active,
+      // onPressed callback is null, by default the flutter wiil read it disable.
                   route: null,
                 ),
                 NavigationButton(


### PR DESCRIPTION
## Related Links:
- [Notion link](https://www.notion.so/Disable-notifications-icon-38f6991ba6ef436794bbafabd4aaf247)

## Definition of Done
- [ ] Able to disable notification Icon


## Notes:
- N/A


## Screenshots
![disableIcon](https://user-images.githubusercontent.com/89514595/165889656-50194d09-a4a6-415e-9d1f-c06f8be59cd2.gif)


## Test View  Points
- [ ] When clicking the notification icon you can't get to it's page
