### PR TITLE
Removed add transaction as child of bottom nav bar

### DIFF
--- a/lib/consts/routes.dart
+++ b/lib/consts/routes.dart
@@ -4,5 +4,5 @@ class Routes {
   static const String notifications = '/user/notifications';
   static const String settings = '/user/account_settings';
   static const String samplecrud = '/user/sample_crud';
-  static const String addTransaction = '/user/add_transaction';
+  static const String addTransaction = '/transaction/add';
 }

--- a/lib/utils/routes/router.dart
+++ b/lib/utils/routes/router.dart
@@ -47,11 +47,6 @@ import 'package:sun_flutter_capstone/views/pages/account_settings/update_basic_i
         page: SampleCrud,
       ),
       AutoRoute(
-        path: 'add_transaction',
-        page: AddTransaction,
-        name: 'AddTransactionRouter',
-      ),
-      AutoRoute(
         path: 'update_basic_info',
         name: 'UpdateBasicInfoRouter',
         page: UpdateBasicInfo,
@@ -62,6 +57,11 @@ import 'package:sun_flutter_capstone/views/pages/account_settings/update_basic_i
         page: SpendingLimit,
       ),
     ],
+  ),
+  AutoRoute(
+    path: '/transaction/add',
+    page: AddTransaction,
+    name: 'AddTransactionRouter',
   ),
 ])
 class $AppRouter {}

--- a/lib/utils/routes/router.gr.dart
+++ b/lib/utils/routes/router.gr.dart
@@ -13,15 +13,15 @@
 import 'package:auto_route/auto_route.dart' as _i11;
 import 'package:flutter/material.dart' as _i12;
 
-import '../../views/pages/account_settings/account_settings.dart' as _i6;
+import '../../views/pages/account_settings/account_settings.dart' as _i7;
 import '../../views/pages/account_settings/spending_limit.dart' as _i10;
 import '../../views/pages/account_settings/update_basic_info.dart' as _i9;
-import '../../views/pages/dashboard.dart' as _i3;
-import '../../views/pages/notifications.dart' as _i5;
+import '../../views/pages/dashboard.dart' as _i4;
+import '../../views/pages/notifications.dart' as _i6;
 import '../../views/pages/session/register.dart' as _i1;
-import '../../views/pages/test/sample_crud.dart' as _i7;
-import '../../views/pages/transactions.dart' as _i4;
-import '../../views/pages/transactions/add_transaction.dart' as _i8;
+import '../../views/pages/test/sample_crud.dart' as _i8;
+import '../../views/pages/transactions.dart' as _i5;
+import '../../views/pages/transactions/add_transaction.dart' as _i3;
 import '../../views/widgets/navigation/bottom_navbar.dart' as _i2;
 
 class AppRouter extends _i11.RootStackRouter {
@@ -38,29 +38,29 @@ class AppRouter extends _i11.RootStackRouter {
       return _i11.MaterialPageX<dynamic>(
           routeData: routeData, child: const _i2.BottomNavBar());
     },
+    AddTransactionRouter.name: (routeData) {
+      return _i11.MaterialPageX<dynamic>(
+          routeData: routeData, child: const _i3.AddTransaction());
+    },
     DashboardRouter.name: (routeData) {
       return _i11.MaterialPageX<dynamic>(
-          routeData: routeData, child: const _i3.Dashboard());
+          routeData: routeData, child: const _i4.Dashboard());
     },
     TransactionRouter.name: (routeData) {
       return _i11.MaterialPageX<dynamic>(
-          routeData: routeData, child: const _i4.TransactionsPage());
+          routeData: routeData, child: const _i5.TransactionsPage());
     },
     NotificationsRouter.name: (routeData) {
       return _i11.MaterialPageX<dynamic>(
-          routeData: routeData, child: const _i5.NotificationsPage());
+          routeData: routeData, child: const _i6.NotificationsPage());
     },
     SettingsRouter.name: (routeData) {
       return _i11.MaterialPageX<dynamic>(
-          routeData: routeData, child: const _i6.AccountSettings());
+          routeData: routeData, child: const _i7.AccountSettings());
     },
     SampleCrud.name: (routeData) {
       return _i11.MaterialPageX<dynamic>(
-          routeData: routeData, child: const _i7.SampleCrud());
-    },
-    AddTransactionRouter.name: (routeData) {
-      return _i11.MaterialPageX<dynamic>(
-          routeData: routeData, child: const _i8.AddTransaction());
+          routeData: routeData, child: const _i8.SampleCrud());
     },
     UpdateBasicInfoRouter.name: (routeData) {
       return _i11.MaterialPageX<dynamic>(
@@ -89,13 +89,12 @@ class AppRouter extends _i11.RootStackRouter {
               path: 'account_settings', parent: BottomNavBar.name),
           _i11.RouteConfig(SampleCrud.name,
               path: 'sample_crud', parent: BottomNavBar.name),
-          _i11.RouteConfig(AddTransactionRouter.name,
-              path: 'add_transaction', parent: BottomNavBar.name),
           _i11.RouteConfig(UpdateBasicInfoRouter.name,
               path: 'update_basic_info', parent: BottomNavBar.name),
           _i11.RouteConfig(SpendingLimitRouter.name,
               path: 'spending_limit', parent: BottomNavBar.name)
-        ])
+        ]),
+        _i11.RouteConfig(AddTransactionRouter.name, path: '/transaction/add')
       ];
 }
 
@@ -117,7 +116,16 @@ class BottomNavBar extends _i11.PageRouteInfo<void> {
 }
 
 /// generated route for
-/// [_i3.Dashboard]
+/// [_i3.AddTransaction]
+class AddTransactionRouter extends _i11.PageRouteInfo<void> {
+  const AddTransactionRouter()
+      : super(AddTransactionRouter.name, path: '/transaction/add');
+
+  static const String name = 'AddTransactionRouter';
+}
+
+/// generated route for
+/// [_i4.Dashboard]
 class DashboardRouter extends _i11.PageRouteInfo<void> {
   const DashboardRouter() : super(DashboardRouter.name, path: 'dashboard');
 
@@ -125,7 +133,7 @@ class DashboardRouter extends _i11.PageRouteInfo<void> {
 }
 
 /// generated route for
-/// [_i4.TransactionsPage]
+/// [_i5.TransactionsPage]
 class TransactionRouter extends _i11.PageRouteInfo<void> {
   const TransactionRouter()
       : super(TransactionRouter.name, path: 'transactions');
@@ -134,7 +142,7 @@ class TransactionRouter extends _i11.PageRouteInfo<void> {
 }
 
 /// generated route for
-/// [_i5.NotificationsPage]
+/// [_i6.NotificationsPage]
 class NotificationsRouter extends _i11.PageRouteInfo<void> {
   const NotificationsRouter()
       : super(NotificationsRouter.name, path: 'notifications');
@@ -143,7 +151,7 @@ class NotificationsRouter extends _i11.PageRouteInfo<void> {
 }
 
 /// generated route for
-/// [_i6.AccountSettings]
+/// [_i7.AccountSettings]
 class SettingsRouter extends _i11.PageRouteInfo<void> {
   const SettingsRouter() : super(SettingsRouter.name, path: 'account_settings');
 
@@ -151,20 +159,11 @@ class SettingsRouter extends _i11.PageRouteInfo<void> {
 }
 
 /// generated route for
-/// [_i7.SampleCrud]
+/// [_i8.SampleCrud]
 class SampleCrud extends _i11.PageRouteInfo<void> {
   const SampleCrud() : super(SampleCrud.name, path: 'sample_crud');
 
   static const String name = 'SampleCrud';
-}
-
-/// generated route for
-/// [_i8.AddTransaction]
-class AddTransactionRouter extends _i11.PageRouteInfo<void> {
-  const AddTransactionRouter()
-      : super(AddTransactionRouter.name, path: 'add_transaction');
-
-  static const String name = 'AddTransactionRouter';
 }
 
 /// generated route for

--- a/lib/views/widgets/navigation/bottom_navbar.dart
+++ b/lib/views/widgets/navigation/bottom_navbar.dart
@@ -21,7 +21,6 @@ class BottomNavBar extends HookConsumerWidget {
         NotificationsRouter(),
         SettingsRouter(),
         SampleCrud(),
-        // AddTransactionRouter(),
         UpdateBasicInfoRouter(),
         SpendingLimitRouter(),
       ],

--- a/lib/views/widgets/navigation/bottom_navbar.dart
+++ b/lib/views/widgets/navigation/bottom_navbar.dart
@@ -21,7 +21,7 @@ class BottomNavBar extends HookConsumerWidget {
         NotificationsRouter(),
         SettingsRouter(),
         SampleCrud(),
-        AddTransactionRouter(),
+        // AddTransactionRouter(),
         UpdateBasicInfoRouter(),
         SpendingLimitRouter(),
       ],

--- a/lib/views/widgets/navigation/floating_action_button.dart
+++ b/lib/views/widgets/navigation/floating_action_button.dart
@@ -2,7 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:sun_flutter_capstone/consts/global_style.dart';
 import 'package:auto_route/auto_route.dart';
+import 'package:sun_flutter_capstone/consts/routes.dart';
 import 'package:sun_flutter_capstone/utils/routes/router.gr.dart';
+import 'package:sun_flutter_capstone/utils/routing.dart';
 
 class CenterActionButton extends HookConsumerWidget {
   const CenterActionButton({Key? key}) : super(key: key);
@@ -14,13 +16,7 @@ class CenterActionButton extends HookConsumerWidget {
       width: 75,
       child: FloatingActionButton(
         onPressed: () {
-          context.pushRoute(
-            BottomNavBar(
-              children: const [
-                AddTransactionRouter(),
-              ],
-            ),
-          );
+          context.router.pushNamed(Routes.addTransaction);
         },
         elevation: 0,
         backgroundColor: AppColor.secondary,


### PR DESCRIPTION
## Related Links:
- [Issue link](https://www.notion.so/Bug-Can-trigger-add-transaction-screen-multiple-times-a6b526264f12416093794db0330e180b)

## Definition of Done
- [ ] remove navbar in add transactions page

## Notes:
- N/A

## Screenshots
![image](https://user-images.githubusercontent.com/86587091/166179045-e13b9e5c-c093-4452-8a4a-7ea7b9d07866.png)


## Test View  Points
- [ ] add transaction page must show after clicking on center floating action button
- [ ] clicking on back button must go back to previously navigated page
- [ ] bottom navbar must not be seen in add transaction page
