### PR TITLE
fixed icon not highlighting by setting current page

### DIFF
--- a/lib/views/pages/dashboard.dart
+++ b/lib/views/pages/dashboard.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:auto_route/auto_route.dart';
 import 'package:sun_flutter_capstone/consts/consts.dart';
 
 import 'package:sun_flutter_capstone/consts/global_style.dart';
@@ -7,6 +8,7 @@ import 'package:sun_flutter_capstone/controllers/account_controller.dart';
 import 'package:sun_flutter_capstone/consts/routes.dart';
 import 'package:sun_flutter_capstone/controllers/spending_limit_controller.dart';
 import 'package:sun_flutter_capstone/controllers/transactions_controller.dart';
+import 'package:sun_flutter_capstone/state/navigation_provider.dart';
 import 'package:sun_flutter_capstone/utils/routing.dart';
 import 'package:sun_flutter_capstone/views/pages/transaction_summary.dart';
 import 'package:sun_flutter_capstone/views/widgets/progress_bar.dart';
@@ -14,6 +16,7 @@ import 'package:sun_flutter_capstone/views/widgets/template.dart';
 import 'package:sun_flutter_capstone/views/widgets/cards/transaction_card.dart';
 import 'package:sun_flutter_capstone/controllers/income_controller.dart';
 import 'package:sun_flutter_capstone/controllers/expense_controller.dart';
+import 'package:sun_flutter_capstone/utils/routes/router.gr.dart';
 
 class Dashboard extends StatefulHookConsumerWidget {
   const Dashboard({
@@ -157,8 +160,10 @@ class _DashboardState extends ConsumerState<Dashboard> {
                         style: TextButton.styleFrom(
                             primary: Colors.black.withOpacity(0.5),
                             textStyle: TextStyle(fontSize: 14)),
-                        onPressed: () =>
-                            redirectTo(context, Routes.transactions),
+                        onPressed: () {
+                          redirectTo(context, Routes.transactions);
+                          setCurrentPage(ref, Routes.transactions);
+                        },
                         child: Text('See all'),
                       ),
                     ],


### PR DESCRIPTION
## Related Links:
- [Issue link](https://www.notion.so/Bug-Upon-clicking-links-to-navigate-to-other-page-icon-is-not-highlighted-13525a23ec2b402cb7042e4f1f67d096)

## Definition of Done
- [ ] credit card icon highlights after clicking "see all" in dashboard


## Notes:
- added line for setting of current page since the icon highlight listens to the navigationProvider (line 28 in navigation_button.dart)
   - setCurrentPage method can be found in lib\state\navigation_provider.dart


## Screenshots
![image](https://user-images.githubusercontent.com/86587091/166181556-ed89d3a2-c91a-4ab0-8b04-c3d5f3408222.png)


## Test View  Points
- [ ] icon is highlighted after clicking "see all" in dashboard
- [ ] screen navigates to transactions summary after clicking "see all" in dashboard
