### PR TITLE
[Bug] Adding expense with no selected category does not get saved to db

### DIFF
--- a/lib/views/pages/transactions/add_expense.dart
+++ b/lib/views/pages/transactions/add_expense.dart
@@ -32,9 +32,13 @@ class _AddExpenseFormState extends ConsumerState<AddExpenseForm> {
     'dateController': TextEditingController(),
   };
 
+  List<String> categoryList =
+      CategoryList.values.map((e) => e.name.capitalize()).toList();
+
   @override
   void initState() {
     super.initState();
+    formInputControllers['categoryController']?.text = categoryList[0];
   }
 
   void onSubmit(Expense? snapshot) async {
@@ -43,10 +47,8 @@ class _AddExpenseFormState extends ConsumerState<AddExpenseForm> {
       final updatedAt = DateTime.now();
 
       Expense expense = Expense();
-      // TODO: Below line gives int errors, put static category id for now
-      //  (int.parse(formInputControllers['categoryController']!.text)) + 1;
-      expense.category_id =
-          (int.parse(formInputControllers['categoryController']!.text)) + 1;
+      expense.category_id = 
+          categoryList.indexOf(formInputControllers['categoryController']!.text) + 1;
       expense.description = formInputControllers['nameController']!.text;
       expense.amount =
           double.parse(formInputControllers['amountController']!.text);

--- a/lib/views/pages/transactions/add_expense.dart
+++ b/lib/views/pages/transactions/add_expense.dart
@@ -32,13 +32,10 @@ class _AddExpenseFormState extends ConsumerState<AddExpenseForm> {
     'dateController': TextEditingController(),
   };
 
-  List<String> categoryList =
-      CategoryList.values.map((e) => e.name.capitalize()).toList();
-
   @override
   void initState() {
     super.initState();
-    formInputControllers['categoryController']?.text = categoryList[0];
+    formInputControllers['categoryController']!.text = "0";
   }
 
   void onSubmit(Expense? snapshot) async {
@@ -47,8 +44,8 @@ class _AddExpenseFormState extends ConsumerState<AddExpenseForm> {
       final updatedAt = DateTime.now();
 
       Expense expense = Expense();
-      expense.category_id = 
-          categoryList.indexOf(formInputControllers['categoryController']!.text) + 1;
+      expense.category_id =
+          int.parse(formInputControllers['categoryController']!.text) + 1;
       expense.description = formInputControllers['nameController']!.text;
       expense.amount =
           double.parse(formInputControllers['amountController']!.text);


### PR DESCRIPTION
## Related Links:
- [Issue link](https://www.notion.so/Bug-Error-in-Add-expense-form-when-there-is-no-selected-category-d820c09d012140a487941177b78d0055)

## Definition of Done
- [ ] expense must be saved to db even if no category was selected


## Notes:
- noticed another bug where the total doesnt immediately reflect, created [another task](https://www.notion.so/Bug-Total-in-Transaction-does-not-update-after-adding-expense-income-fe75af97a5c94a2a8abf88038bdfd71b) for this
- added default value of categoryController in initState


## Screenshots
https://user-images.githubusercontent.com/86587091/166197588-b78d4a4b-427d-452b-bf33-683209c0cbca.mp4


## Test View  Points
- [ ] add expense with no category selected
- [ ] add expense selecting "food" category 